### PR TITLE
Feature: Add support for `MapAsync`, `BindAsync` and `Sequence`

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,59 @@ public void Try_can_wrap_caught_exceptions()
         .Do((actual) => Assert.Equal("a string", actual));
 }
 ```
+
+## Async Support
+
+Support of async workflows is added a small set of extension methods. Sync operations work naturally after an `await`, and only callbacks that are themselves async need async-specific methods.
+
+### Awaiting then chaining sync operations
+
+When an async function returns an `Option<T>`, `Result<TError, T>`, or `Try<T>`, you can `await` it and then chain any sync operation as usual:
+
+```csharp
+async Task<Option<int>> FindUserId(string username) { ... }
+
+var result = (await FindUserId("malin"))
+    .Map(id => id * 2)
+    .Filter(id => id > 0)
+    .DefaultWith(() => -1);
+```
+
+### BindAsync and MapAsync
+
+When the callback itself is async, `BindAsync` and `MapAsync` enable fluent chaining without intermediate awaits:
+
+```csharp
+async Task<Option<string>> FindUserEmail(int userId) { ... }
+async Task<string> NormalizeEmail(string email) { ... }
+
+var result = await FindUserId("malin")
+    .BindAsync(id => FindUserEmail(id))
+    .MapAsync(email => NormalizeEmail(email));
+```
+
+These work the same way on `Result` and `Try`:
+
+```csharp
+async Task<Result<string, int>> ParseUserId(string input) { ... }
+async Task<Result<string, string>> LookupUsername(int userId) { ... }
+
+var greeting = (await ParseUserId("42")
+        .BindAsync(id => LookupUsername(id)))
+    .Map(name => $"Welcome, {name}!")
+    .DefaultWith(error => $"Error: {error}");
+```
+
+### Sequence
+
+When you have a sync monad and `Map` it with an async function, you get e.g. `Option<Task<T>>`. `Sequence` flips this into `Task<Option<T>>` so you can `await` it:
+
+```csharp
+Option<string> email = Option<string>.Some("  ALICE@EXAMPLE.COM  ");
+
+var result = await email
+    .Map(e => NormalizeEmail(e))
+    .Sequence();
+```
+
+This also works on `Result` and `Try`, skipping the async work when in the error/none state.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ public void Try_can_wrap_caught_exceptions()
 
 ## Async Support
 
-Support of async workflows is added a small set of extension methods. Sync operations work naturally after an `await`, and only callbacks that are themselves async need async-specific methods.
+Support of async workflows is added as a small set of extension methods. Sync operations work naturally after an `await`, and only callbacks that are themselves async need async-specific methods.
 
 ### Awaiting then chaining sync operations
 

--- a/src/Option/AsyncOptionExtensions.cs
+++ b/src/Option/AsyncOptionExtensions.cs
@@ -5,6 +5,10 @@ namespace Svan.Monads
 {
     public static class AsyncOptionExtensions
     {
+        /// <summary>
+        /// Flips an <c>Option&lt;Task&lt;T&gt;&gt;</c> into a <c>Task&lt;Option&lt;T&gt;&gt;</c>.
+        /// Awaits the inner task when <c>Some</c>, returns <c>None</c> immediately when <c>None</c>.
+        /// </summary>
         public static async Task<Option<T>> Sequence<T>(this Option<Task<T>> optionTask)
         {
             if (optionTask.IsNone())
@@ -16,7 +20,11 @@ namespace Svan.Monads
             var result = await task.ConfigureAwait(false);
             return Option<T>.Some(result);
         }
-        
+
+        /// <summary>
+        /// Binds an async function over a <c>Task&lt;Option&lt;T&gt;&gt;</c>.
+        /// The binder is only called when the option is <c>Some</c>; otherwise short-circuits to <c>None</c>.
+        /// </summary>
         public static async Task<Option<TOut>> BindAsync<T, TOut>(
             this Task<Option<T>> optionTask,
             Func<T, Task<Option<TOut>>> binder)
@@ -25,6 +33,10 @@ namespace Svan.Monads
             return option.IsSome() ? await binder(option.Value()).ConfigureAwait(false) : Option<TOut>.None();
         }
 
+        /// <summary>
+        /// Maps an async function over a <c>Task&lt;Option&lt;T&gt;&gt;</c>.
+        /// The mapper is only called when the option is <c>Some</c>; otherwise short-circuits to <c>None</c>.
+        /// </summary>
         public static async Task<Option<TOut>> MapAsync<T, TOut>(
             this Task<Option<T>> optionTask,
             Func<T, Task<TOut>> mapper)

--- a/src/Option/AsyncOptionExtensions.cs
+++ b/src/Option/AsyncOptionExtensions.cs
@@ -13,7 +13,7 @@ namespace Svan.Monads
             }
 
             var task = optionTask.Value();
-            var result = await task;
+            var result = await task.ConfigureAwait(false);
             return Option<T>.Some(result);
         }
         
@@ -21,16 +21,16 @@ namespace Svan.Monads
             this Task<Option<T>> optionTask,
             Func<T, Task<Option<TOut>>> binder)
         {
-            var option = await optionTask;
-            return option.IsSome() ? await binder(option.Value()) : Option<TOut>.None();
+            var option = await optionTask.ConfigureAwait(false);
+            return option.IsSome() ? await binder(option.Value()).ConfigureAwait(false) : Option<TOut>.None();
         }
 
         public static async Task<Option<TOut>> MapAsync<T, TOut>(
             this Task<Option<T>> optionTask,
             Func<T, Task<TOut>> mapper)
         {
-            var option = await optionTask;
-            return option.IsSome() ? Option<TOut>.Some(await mapper(option.Value())) : Option<TOut>.None();
+            var option = await optionTask.ConfigureAwait(false);
+            return option.IsSome() ? Option<TOut>.Some(await mapper(option.Value()).ConfigureAwait(false)) : Option<TOut>.None();
         }
     }
 }

--- a/src/Option/AsyncOptionExtensions.cs
+++ b/src/Option/AsyncOptionExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Svan.Monads
+{
+    public static class AsyncOptionExtensions
+    {
+        public static async Task<Option<TOut>> BindAsync<T, TOut>(
+            this Task<Option<T>> optionTask,
+            Func<T, Task<Option<TOut>>> binder)
+        {
+            var option = await optionTask;
+            return option.IsSome() ? await binder(option.Value()) : Option<TOut>.None();
+        }
+
+        public static async Task<Option<TOut>> MapAsync<T, TOut>(
+            this Task<Option<T>> optionTask,
+            Func<T, Task<TOut>> mapper)
+        {
+            var option = await optionTask;
+            return option.IsSome() ? Option<TOut>.Some(await mapper(option.Value())) : Option<TOut>.None();
+        }
+    }
+}

--- a/src/Option/AsyncOptionExtensions.cs
+++ b/src/Option/AsyncOptionExtensions.cs
@@ -5,6 +5,18 @@ namespace Svan.Monads
 {
     public static class AsyncOptionExtensions
     {
+        public static async Task<Option<T>> Sequence<T>(this Option<Task<T>> optionTask)
+        {
+            if (optionTask.IsNone())
+            {
+                return Option<T>.None();
+            }
+
+            var task = optionTask.Value();
+            var result = await task;
+            return Option<T>.Some(result);
+        }
+        
         public static async Task<Option<TOut>> BindAsync<T, TOut>(
             this Task<Option<T>> optionTask,
             Func<T, Task<Option<TOut>>> binder)

--- a/src/Option/Option.cs
+++ b/src/Option/Option.cs
@@ -22,7 +22,7 @@ namespace Svan.Monads
     public struct None { };
 
     /// <summary>
-    /// Union of <c>None</c> and <c>Some<T></c> with monad features for the Maybe flow control
+    /// Union of <c>None</c> and <c>Some&lt;T&gt;</c> with monad features for the Maybe flow control
     /// </summary>
     public class Option<T> : OneOfBase<None, Some<T>>
     {
@@ -34,7 +34,14 @@ namespace Svan.Monads
         public static Option<T> None() => new None();
         public static Option<T> Some(T value) => new Some<T>(value);
 
+        /// <summary>
+        /// Returns <c>true</c> if the option is <c>None</c>.
+        /// </summary>
         public bool IsNone() => this.IsT0;
+
+        /// <summary>
+        /// Returns <c>true</c> if the option is <c>Some</c>.
+        /// </summary>
         public bool IsSome() => this.IsT1;
 
         /// <summary>
@@ -43,9 +50,9 @@ namespace Svan.Monads
         new public T Value() => IsSome() ? this.AsT1.Value : throw new NullReferenceException();
 
         /// <summary>
-        /// Bind the <c>Option<T></c> to an <c>Option<TOut></c> using a binder function. The binder function will not be executed if the current state of the option is <c>None</c>.
+        /// Bind the <c>Option&lt;T&gt;</c> to an <c>Option&lt;TOut&gt;</c> using a binder function. The binder function will not be executed if the current state of the option is <c>None</c>.
         /// </summary>
-        /// <param name="binder">A function that returns an <c>Option<TOut></c></param>
+        /// <param name="binder">A function that returns an <c>Option&lt;TOut&gt;</c></param>
         /// <returns>An option of the output type of the binder. </returns>
         public Option<TOut> Bind<TOut>(Func<T, Option<TOut>> binder)
             => Match(
@@ -53,7 +60,7 @@ namespace Svan.Monads
                 some => binder(some.Value));
 
         /// <summary>
-        /// Map the value of the option to an <c>Option<TOut></c> using a mapping function. The mapping function will not be executed if the current state of the option is <c>None</c>.
+        /// Map the value of the option to an <c>Option&lt;TOut&gt;</c> using a mapping function. The mapping function will not be executed if the current state of the option is <c>None</c>.
         /// </summary>
         /// <param name="mapping">A function that returns a value of <c>TOut</c></param>
         /// <typeparam name="TOut"></typeparam>
@@ -74,7 +81,7 @@ namespace Svan.Monads
                 some => filter(some.Value) ? some : None());
 
         /// <summary>
-        /// Do let's you fire and forget an action that is executed only when the value is Some<T>
+        /// Do let's you fire and forget an action that is executed only when the value is <c>Some&lt;T&gt;</c>
         /// </summary>
         /// <param name="do">An action that takes a single parameter of T</param>
         /// <returns>The current state of the Option</returns>
@@ -208,7 +215,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Create a <c>Result<TError, T></c> from an Option<T> by supplying a mapper for the error case
+        /// Create a <c>Result&lt;TError, T&gt;</c> from an <c>Option&lt;T&gt;</c> by supplying a mapper for the error case
         /// </summary>
 
         public Result<TError, T> ToResult<TError>(Func<TError> defaultError)

--- a/src/Result/AsyncResultExtensions.cs
+++ b/src/Result/AsyncResultExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Svan.Monads
+{
+    public static class AsyncResultExtensions
+    {
+        public static async Task<Result<TError, TOut>> BindAsync<TError, TSuccess, TOut>(
+            this Task<Result<TError, TSuccess>> resultTask,
+            Func<TSuccess, Task<Result<TError, TOut>>> binder)
+        {
+            var result = await resultTask;
+            return result.IsSuccess() ? await binder(result.SuccessValue()) : Result<TError, TOut>.Error(result.ErrorValue());
+        }
+
+        public static async Task<Result<TError, TOut>> MapAsync<TError, TSuccess, TOut>(
+            this Task<Result<TError, TSuccess>> resultTask,
+            Func<TSuccess, Task<TOut>> mapper)
+        {
+            var result = await resultTask;
+            return result.IsSuccess() ? Result<TError, TOut>.Success(await mapper(result.SuccessValue())) : Result<TError, TOut>.Error(result.ErrorValue());
+        }
+    }
+}

--- a/src/Result/AsyncResultExtensions.cs
+++ b/src/Result/AsyncResultExtensions.cs
@@ -5,6 +5,10 @@ namespace Svan.Monads
 {
     public static class AsyncResultExtensions
     {
+        /// <summary>
+        /// Flips a <c>Result&lt;TError, Task&lt;TSuccess&gt;&gt;</c> into a <c>Task&lt;Result&lt;TError, TSuccess&gt;&gt;</c>.
+        /// Awaits the inner task when <c>Success</c>, returns the error immediately when <c>Error</c>.
+        /// </summary>
         public static async Task<Result<TError, TSuccess>> Sequence<TError, TSuccess>(
             this Result<TError, Task<TSuccess>> resultTask)
         {
@@ -17,6 +21,10 @@ namespace Svan.Monads
             return Result<TError, TSuccess>.Success(value);
         }
 
+        /// <summary>
+        /// Binds an async function over a <c>Task&lt;Result&lt;TError, TSuccess&gt;&gt;</c>.
+        /// The binder is only called when the result is <c>Success</c>; otherwise short-circuits with the existing error.
+        /// </summary>
         public static async Task<Result<TError, TOut>> BindAsync<TError, TSuccess, TOut>(
             this Task<Result<TError, TSuccess>> resultTask,
             Func<TSuccess, Task<Result<TError, TOut>>> binder)
@@ -25,6 +33,10 @@ namespace Svan.Monads
             return result.IsSuccess() ? await binder(result.SuccessValue()).ConfigureAwait(false) : Result<TError, TOut>.Error(result.ErrorValue());
         }
 
+        /// <summary>
+        /// Maps an async function over a <c>Task&lt;Result&lt;TError, TSuccess&gt;&gt;</c>.
+        /// The mapper is only called when the result is <c>Success</c>; otherwise short-circuits with the existing error.
+        /// </summary>
         public static async Task<Result<TError, TOut>> MapAsync<TError, TSuccess, TOut>(
             this Task<Result<TError, TSuccess>> resultTask,
             Func<TSuccess, Task<TOut>> mapper)

--- a/src/Result/AsyncResultExtensions.cs
+++ b/src/Result/AsyncResultExtensions.cs
@@ -5,6 +5,18 @@ namespace Svan.Monads
 {
     public static class AsyncResultExtensions
     {
+        public static async Task<Result<TError, TSuccess>> Sequence<TError, TSuccess>(
+            this Result<TError, Task<TSuccess>> resultTask)
+        {
+            if (resultTask.IsError())
+            {
+                return Result<TError, TSuccess>.Error(resultTask.ErrorValue());
+            }
+
+            var value = await resultTask.SuccessValue();
+            return Result<TError, TSuccess>.Success(value);
+        }
+
         public static async Task<Result<TError, TOut>> BindAsync<TError, TSuccess, TOut>(
             this Task<Result<TError, TSuccess>> resultTask,
             Func<TSuccess, Task<Result<TError, TOut>>> binder)

--- a/src/Result/AsyncResultExtensions.cs
+++ b/src/Result/AsyncResultExtensions.cs
@@ -13,7 +13,7 @@ namespace Svan.Monads
                 return Result<TError, TSuccess>.Error(resultTask.ErrorValue());
             }
 
-            var value = await resultTask.SuccessValue();
+            var value = await resultTask.SuccessValue().ConfigureAwait(false);
             return Result<TError, TSuccess>.Success(value);
         }
 
@@ -21,16 +21,16 @@ namespace Svan.Monads
             this Task<Result<TError, TSuccess>> resultTask,
             Func<TSuccess, Task<Result<TError, TOut>>> binder)
         {
-            var result = await resultTask;
-            return result.IsSuccess() ? await binder(result.SuccessValue()) : Result<TError, TOut>.Error(result.ErrorValue());
+            var result = await resultTask.ConfigureAwait(false);
+            return result.IsSuccess() ? await binder(result.SuccessValue()).ConfigureAwait(false) : Result<TError, TOut>.Error(result.ErrorValue());
         }
 
         public static async Task<Result<TError, TOut>> MapAsync<TError, TSuccess, TOut>(
             this Task<Result<TError, TSuccess>> resultTask,
             Func<TSuccess, Task<TOut>> mapper)
         {
-            var result = await resultTask;
-            return result.IsSuccess() ? Result<TError, TOut>.Success(await mapper(result.SuccessValue())) : Result<TError, TOut>.Error(result.ErrorValue());
+            var result = await resultTask.ConfigureAwait(false);
+            return result.IsSuccess() ? Result<TError, TOut>.Success(await mapper(result.SuccessValue()).ConfigureAwait(false)) : Result<TError, TOut>.Error(result.ErrorValue());
         }
     }
 }

--- a/src/Try/AsyncTryExtensions.cs
+++ b/src/Try/AsyncTryExtensions.cs
@@ -5,6 +5,14 @@ namespace Svan.Monads
 {
     public static class AsyncTryExtensions
     {
+        public static async Task<Try<TSuccess>> Sequence<TSuccess>(
+            this Try<Task<TSuccess>> tryTask)
+        {
+            if (tryTask.IsError())
+                return tryTask.ErrorValue();
+            return await tryTask.SuccessValue();
+        }
+
         public static async Task<Try<TOut>> BindAsync<TSuccess, TOut>(
             this Task<Try<TSuccess>> tryTask,
             Func<TSuccess, Task<Try<TOut>>> binder)

--- a/src/Try/AsyncTryExtensions.cs
+++ b/src/Try/AsyncTryExtensions.cs
@@ -10,16 +10,16 @@ namespace Svan.Monads
         {
             if (tryTask.IsError())
                 return tryTask.ErrorValue();
-            return await tryTask.SuccessValue();
+            return await tryTask.SuccessValue().ConfigureAwait(false);
         }
 
         public static async Task<Try<TOut>> BindAsync<TSuccess, TOut>(
             this Task<Try<TSuccess>> tryTask,
             Func<TSuccess, Task<Try<TOut>>> binder)
         {
-            var result = await tryTask;
+            var result = await tryTask.ConfigureAwait(false);
             if (result.IsSuccess())
-                return await binder(result.SuccessValue());
+                return await binder(result.SuccessValue()).ConfigureAwait(false);
             return result.ErrorValue();
         }
 
@@ -27,9 +27,9 @@ namespace Svan.Monads
             this Task<Try<TSuccess>> tryTask,
             Func<TSuccess, Task<TOut>> mapper)
         {
-            var result = await tryTask;
+            var result = await tryTask.ConfigureAwait(false);
             if (result.IsSuccess())
-                return await mapper(result.SuccessValue());
+                return await mapper(result.SuccessValue()).ConfigureAwait(false);
             return result.ErrorValue();
         }
     }

--- a/src/Try/AsyncTryExtensions.cs
+++ b/src/Try/AsyncTryExtensions.cs
@@ -5,6 +5,10 @@ namespace Svan.Monads
 {
     public static class AsyncTryExtensions
     {
+        /// <summary>
+        /// Flips a <c>Try&lt;Task&lt;TSuccess&gt;&gt;</c> into a <c>Task&lt;Try&lt;TSuccess&gt;&gt;</c>.
+        /// Awaits the inner task when <c>Success</c>, returns the error immediately when <c>Error</c>.
+        /// </summary>
         public static async Task<Try<TSuccess>> Sequence<TSuccess>(
             this Try<Task<TSuccess>> tryTask)
         {
@@ -13,6 +17,12 @@ namespace Svan.Monads
             return await tryTask.SuccessValue().ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Binds an async function over a <c>Task&lt;Try&lt;TSuccess&gt;&gt;</c>.
+        /// The binder is only called when the result is <c>Success</c>; otherwise short-circuits with the existing error.
+        /// Exceptions thrown by the binder or faulted tasks will propagate as faulted tasks.
+        /// Use <see cref="BindCatchingAsync{TSuccess, TOut}"/> to catch exceptions into the error state instead.
+        /// </summary>
         public static async Task<Try<TOut>> BindAsync<TSuccess, TOut>(
             this Task<Try<TSuccess>> tryTask,
             Func<TSuccess, Task<Try<TOut>>> binder)
@@ -23,6 +33,12 @@ namespace Svan.Monads
             return result.ErrorValue();
         }
 
+        /// <summary>
+        /// Maps an async function over a <c>Task&lt;Try&lt;TSuccess&gt;&gt;</c>.
+        /// The mapper is only called when the result is <c>Success</c>; otherwise short-circuits with the existing error.
+        /// Exceptions thrown by the mapper or faulted tasks will propagate as faulted tasks.
+        /// Use <see cref="MapCatchingAsync{TSuccess, TOut}"/> to catch exceptions into the error state instead.
+        /// </summary>
         public static async Task<Try<TOut>> MapAsync<TSuccess, TOut>(
             this Task<Try<TSuccess>> tryTask,
             Func<TSuccess, Task<TOut>> mapper)
@@ -33,6 +49,11 @@ namespace Svan.Monads
             return result.ErrorValue();
         }
 
+        /// <summary>
+        /// Binds an async function over a <c>Task&lt;Try&lt;TSuccess&gt;&gt;</c>, catching any exceptions.
+        /// Exceptions thrown by the binder or faulted tasks are caught and returned as the error state,
+        /// keeping the chain inside the monad.
+        /// </summary>
         public static async Task<Try<TOut>> BindCatchingAsync<TSuccess, TOut>(
             this Task<Try<TSuccess>> tryTask,
             Func<TSuccess, Task<Try<TOut>>> binder)
@@ -52,6 +73,11 @@ namespace Svan.Monads
             return result.ErrorValue();
         }
 
+        /// <summary>
+        /// Maps an async function over a <c>Task&lt;Try&lt;TSuccess&gt;&gt;</c>, catching any exceptions.
+        /// Exceptions thrown by the mapper or faulted tasks are caught and returned as the error state,
+        /// keeping the chain inside the monad.
+        /// </summary>
         public static async Task<Try<TOut>> MapCatchingAsync<TSuccess, TOut>(
             this Task<Try<TSuccess>> tryTask,
             Func<TSuccess, Task<TOut>> mapper)

--- a/src/Try/AsyncTryExtensions.cs
+++ b/src/Try/AsyncTryExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Svan.Monads
+{
+    public static class AsyncTryExtensions
+    {
+        public static async Task<Try<TOut>> BindAsync<TSuccess, TOut>(
+            this Task<Try<TSuccess>> tryTask,
+            Func<TSuccess, Task<Try<TOut>>> binder)
+        {
+            var result = await tryTask;
+            if (result.IsSuccess())
+                return await binder(result.SuccessValue());
+            return result.ErrorValue();
+        }
+
+        public static async Task<Try<TOut>> MapAsync<TSuccess, TOut>(
+            this Task<Try<TSuccess>> tryTask,
+            Func<TSuccess, Task<TOut>> mapper)
+        {
+            var result = await tryTask;
+            if (result.IsSuccess())
+                return await mapper(result.SuccessValue());
+            return result.ErrorValue();
+        }
+    }
+}

--- a/src/Try/AsyncTryExtensions.cs
+++ b/src/Try/AsyncTryExtensions.cs
@@ -32,5 +32,43 @@ namespace Svan.Monads
                 return await mapper(result.SuccessValue()).ConfigureAwait(false);
             return result.ErrorValue();
         }
+
+        public static async Task<Try<TOut>> BindCatchingAsync<TSuccess, TOut>(
+            this Task<Try<TSuccess>> tryTask,
+            Func<TSuccess, Task<Try<TOut>>> binder)
+        {
+            var result = await tryTask.ConfigureAwait(false);
+            if (result.IsSuccess())
+            {
+                try
+                {
+                    return await binder(result.SuccessValue()).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    return ex;
+                }
+            }
+            return result.ErrorValue();
+        }
+
+        public static async Task<Try<TOut>> MapCatchingAsync<TSuccess, TOut>(
+            this Task<Try<TSuccess>> tryTask,
+            Func<TSuccess, Task<TOut>> mapper)
+        {
+            var result = await tryTask.ConfigureAwait(false);
+            if (result.IsSuccess())
+            {
+                try
+                {
+                    return await mapper(result.SuccessValue()).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    return ex;
+                }
+            }
+            return result.ErrorValue();
+        }
     }
 }

--- a/src/Try/AsyncTryExtensions.cs
+++ b/src/Try/AsyncTryExtensions.cs
@@ -8,13 +8,21 @@ namespace Svan.Monads
         /// <summary>
         /// Flips a <c>Try&lt;Task&lt;TSuccess&gt;&gt;</c> into a <c>Task&lt;Try&lt;TSuccess&gt;&gt;</c>.
         /// Awaits the inner task when <c>Success</c>, returns the error immediately when <c>Error</c>.
+        /// If the inner task faults, the exception is caught and returned as the error state.
         /// </summary>
         public static async Task<Try<TSuccess>> Sequence<TSuccess>(
             this Try<Task<TSuccess>> tryTask)
         {
             if (tryTask.IsError())
                 return tryTask.ErrorValue();
-            return await tryTask.SuccessValue().ConfigureAwait(false);
+            try
+            {
+                return await tryTask.SuccessValue().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
         }
 
         /// <summary>

--- a/src/Try/Try.cs
+++ b/src/Try/Try.cs
@@ -4,8 +4,15 @@ using OneOf;
 
 namespace Svan.Monads
 {
+    /// <summary>
+    /// Factory for creating <c>Try&lt;TSuccess&gt;</c> instances by catching exceptions.
+    /// </summary>
     public static class Try
     {
+        /// <summary>
+        /// Execute <paramref name="codeBlock"/> and return its result as <c>Success</c>.
+        /// If the code block throws, the exception is caught and returned as the error state.
+        /// </summary>
         public static Try<TSuccess> Catching<TSuccess>(Func<TSuccess> codeBlock)
         {
             try
@@ -19,6 +26,9 @@ namespace Svan.Monads
         }
     }
 
+    /// <summary>
+    /// A specialization of <c>Result&lt;Exception, TSuccess&gt;</c> that provides exception-catching operations.
+    /// </summary>
     public class Try<TSuccess> : Result<Exception, TSuccess>
     {
         public Try(OneOf<Error<Exception>, Success<TSuccess>> _) : base(_) { }
@@ -27,13 +37,23 @@ namespace Svan.Monads
         public static implicit operator Try<TSuccess>(TSuccess _) => new Success<TSuccess>(_);
         public static implicit operator Try<TSuccess>(Exception _) => new Error<Exception>(_);
 
+        /// <summary>
+        /// Upcast to <c>Result&lt;Exception, TSuccess&gt;</c>.
+        /// </summary>
         public Result<Exception, TSuccess> ToResult() => this;
 
+        /// <summary>
+        /// Map the success value using a mapping function, catching any exception thrown by the mapper.
+        /// </summary>
         public Try<TOut> MapCatching<TOut>(Func<TSuccess, TOut> mapper)
             => Fold(
                  error => error,
                  success => Try.Catching(() => mapper(success)));
 
+        /// <summary>
+        /// Bind using a binder function, catching any exception thrown by the binder.
+        /// The binder is only called when <c>Success</c>; otherwise short-circuits with the existing error.
+        /// </summary>
         public Try<TOut> BindCatching<TOut>(Func<TSuccess, Try<TOut>> binder)
         {
             if (IsSuccess())
@@ -50,6 +70,11 @@ namespace Svan.Monads
             return ErrorValue();
         }
 
+        /// <summary>
+        /// Bind using a binder function.
+        /// The binder is only called when <c>Success</c>; otherwise short-circuits with the existing error.
+        /// Exceptions thrown by the binder will propagate. Use <see cref="BindCatching{TOut}"/> to catch them instead.
+        /// </summary>
         public new Try<TOut> Bind<TOut>(Func<TSuccess, Try<TOut>> binder)
         {
             if (IsSuccess())
@@ -57,6 +82,11 @@ namespace Svan.Monads
             return ErrorValue();
         }
 
+        /// <summary>
+        /// Map the success value to a new type using a mapping function.
+        /// The mapper is only called when <c>Success</c>; otherwise short-circuits with the existing error.
+        /// Exceptions thrown by the mapper will propagate. Use <see cref="MapCatching{TOut}"/> to catch them instead.
+        /// </summary>
         public new Try<TOut> Map<TOut>(Func<TSuccess, TOut> mapper)
         {
             if (IsSuccess())

--- a/src/Try/Try.cs
+++ b/src/Try/Try.cs
@@ -50,7 +50,7 @@ namespace Svan.Monads
             return ErrorValue();
         }
 
-        public Try<TOut> Bind<TOut>(Func<TSuccess, Try<TOut>> binder)
+        public new Try<TOut> Bind<TOut>(Func<TSuccess, Try<TOut>> binder)
         {
             if (IsSuccess())
                 return binder(SuccessValue());

--- a/src/Try/Try.cs
+++ b/src/Try/Try.cs
@@ -35,28 +35,42 @@ namespace Svan.Monads
                  success => Try.Catching(() => mapper(success)));
 
         public Try<TOut> Bind<TOut>(Func<TSuccess, Try<TOut>> binder)
-            => base.Bind<TOut>(binder) as Try<TOut>;
+        {
+            if (IsSuccess())
+                return binder(SuccessValue());
+            return ErrorValue();
+        }
 
         public new Try<TOut> Map<TOut>(Func<TSuccess, TOut> mapper)
-            => base.Map<TOut>(mapper) as Try<TOut>;
-
+        {
+            if (IsSuccess())
+                return mapper(SuccessValue());
+            return ErrorValue();
+        }
 
         /// <summary>
-        /// Do let's you fire and forget an action that is executed only when the value is <see cref="TSuccess"/> 
+        /// Do let's you fire and forget an action that is executed only when the value is <see cref="TSuccess"/>
         /// </summary>
         /// <param name="do">An action that takes a single parameter of <see cref="TSuccess"/></param>
         /// <returns>The current state of the Result</returns>
         public new Try<TSuccess> Do(Action<TSuccess> @do)
-            => base.Do(@do) as Try<TSuccess>;
+        {
+            if (IsSuccess())
+                @do(SuccessValue());
+            return this;
+        }
 
         /// <summary>
-        /// Do let's you fire and forget an action that is executed only when the value is <see cref="TError"/> 
+        /// Do let's you fire and forget an action that is executed only when the value is <see cref="TError"/>
         /// </summary>
         /// <param name="do">An action that takes a single parameter of <see cref="TError"/></param>
         /// <returns>The current state of the Result</returns>
         public new Try<TSuccess> DoIfError(Action<Exception> @do)
-            => base.DoIfError(@do) as Try<TSuccess>;
-
+        {
+            if (IsError())
+                @do(ErrorValue());
+            return this;
+        }
 
         /// <summary>
         /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
@@ -64,7 +78,12 @@ namespace Svan.Monads
         public Try<TSuccessOut> Zip<TSuccessOut, TSuccessOther>(
             Try<TSuccessOther> other,
             Func<TSuccess, TSuccessOther, TSuccessOut> combine)
-                => base.Zip(other, combine) as Try<TSuccessOut>;
+        {
+            var result = base.Zip(other, combine);
+            if (result.IsSuccess())
+                return result.SuccessValue();
+            return result.ErrorValue();
+        }
 
         /// <summary>
         /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
@@ -73,7 +92,12 @@ namespace Svan.Monads
             Try<TSuccessFirstOther> firstOther,
             Try<TSuccessSecondOther> secondOther,
             Func<TSuccess, TSuccessFirstOther, TSuccessSecondOther, TSuccessOut> combine)
-                => base.Zip(firstOther, secondOther, combine) as Try<TSuccessOut>;
+        {
+            var result = base.Zip(firstOther, secondOther, combine);
+            if (result.IsSuccess())
+                return result.SuccessValue();
+            return result.ErrorValue();
+        }
 
         /// <summary>
         /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
@@ -83,7 +107,12 @@ namespace Svan.Monads
             Try<TSuccessSecondOther> secondOther,
             Try<TSuccessThirdOther> thirdOther,
             Func<TSuccess, TSuccessFirstOther, TSuccessSecondOther, TSuccessThirdOther, TSuccessOut> combine)
-                => base.Zip(firstOther, secondOther, thirdOther, combine) as Try<TSuccessOut>;
+        {
+            var result = base.Zip(firstOther, secondOther, thirdOther, combine);
+            if (result.IsSuccess())
+                return result.SuccessValue();
+            return result.ErrorValue();
+        }
 
         /// <summary>
         /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
@@ -105,6 +134,11 @@ namespace Svan.Monads
                 TSuccessThirdOther,
                 TSuccessFourthOther,
                 TSuccessOut> combine)
-                    => base.Zip(firstOther, secondOther, thirdOther, fourthOther, combine) as Try<TSuccessOut>;
+        {
+            var result = base.Zip(firstOther, secondOther, thirdOther, fourthOther, combine);
+            if (result.IsSuccess())
+                return result.SuccessValue();
+            return result.ErrorValue();
+        }
     }
 }

--- a/src/Try/Try.cs
+++ b/src/Try/Try.cs
@@ -34,6 +34,22 @@ namespace Svan.Monads
                  error => error,
                  success => Try.Catching(() => mapper(success)));
 
+        public Try<TOut> BindCatching<TOut>(Func<TSuccess, Try<TOut>> binder)
+        {
+            if (IsSuccess())
+            {
+                try
+                {
+                    return binder(SuccessValue());
+                }
+                catch (Exception ex)
+                {
+                    return ex;
+                }
+            }
+            return ErrorValue();
+        }
+
         public Try<TOut> Bind<TOut>(Func<TSuccess, Try<TOut>> binder)
         {
             if (IsSuccess())

--- a/src/Try/Try.cs
+++ b/src/Try/Try.cs
@@ -91,7 +91,7 @@ namespace Svan.Monads
         /// <summary>
         /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
         /// </summary>
-        public Try<TSuccessOut> Zip<TSuccessOut, TSuccessOther>(
+        public new Try<TSuccessOut> Zip<TSuccessOut, TSuccessOther>(
             Try<TSuccessOther> other,
             Func<TSuccess, TSuccessOther, TSuccessOut> combine)
         {
@@ -104,7 +104,7 @@ namespace Svan.Monads
         /// <summary>
         /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
         /// </summary>
-        public Try<TSuccessOut> Zip<TSuccessOut, TSuccessFirstOther, TSuccessSecondOther>(
+        public new Try<TSuccessOut> Zip<TSuccessOut, TSuccessFirstOther, TSuccessSecondOther>(
             Try<TSuccessFirstOther> firstOther,
             Try<TSuccessSecondOther> secondOther,
             Func<TSuccess, TSuccessFirstOther, TSuccessSecondOther, TSuccessOut> combine)
@@ -118,7 +118,7 @@ namespace Svan.Monads
         /// <summary>
         /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
         /// </summary>
-        public Try<TSuccessOut> Zip<TSuccessOut, TSuccessFirstOther, TSuccessSecondOther, TSuccessThirdOther>(
+        public new Try<TSuccessOut> Zip<TSuccessOut, TSuccessFirstOther, TSuccessSecondOther, TSuccessThirdOther>(
             Try<TSuccessFirstOther> firstOther,
             Try<TSuccessSecondOther> secondOther,
             Try<TSuccessThirdOther> thirdOther,
@@ -133,7 +133,7 @@ namespace Svan.Monads
         /// <summary>
         /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
         /// </summary>
-        public Try<TSuccessOut> Zip<
+        public new Try<TSuccessOut> Zip<
             TSuccessOut,
             TSuccessFirstOther,
             TSuccessSecondOther,

--- a/tests/AsyncOptionTests.cs
+++ b/tests/AsyncOptionTests.cs
@@ -1,0 +1,112 @@
+using Xunit;
+using Svan.Monads;
+
+namespace Svan.Monads.UnitTest
+{
+    public class AsyncOptionTests
+    {
+        private async Task<Option<int>> FindUserId(string username)
+        {
+            await Task.Yield();
+            return username == "varmkorv" ? Option<int>.Some(42) : Option<int>.None();
+        }
+
+        private async Task<Option<string>> FindUserEmail(int userId)
+        {
+            await Task.Yield();
+            return userId == 42
+                ? Option<string>.Some("varmkorv@example.com")
+                : Option<string>.None();
+        }
+
+        private async Task<string> NormalizeEmail(string email)
+        {
+            await Task.Yield();
+            return email.Trim().ToLowerInvariant();
+        }
+
+        [Fact]
+        public async Task Await_then_map_filter_and_fold()
+        {
+            var result = (await FindUserId("varmkorv"))
+                .Map(id => id * 2)
+                .Filter(id => id > 0)
+                .Fold(() => -1, id => id);
+
+            Assert.Equal(84, result);
+        }
+
+        [Fact]
+        public async Task Await_then_fold_on_none()
+        {
+            var result = (await FindUserId("unknown"))
+                .Fold(
+                    () => "not found",
+                    id => $"found: {id}");
+
+            Assert.Equal("not found", result);
+        }
+
+        [Fact]
+        public async Task Await_then_default_with()
+        {
+            var result = (await FindUserId("unknown"))
+                .DefaultWith(() => -1);
+
+            Assert.Equal(-1, result);
+        }
+
+        [Fact]
+        public async Task Sequential_async_calls_with_intermediate_awaits()
+        {
+            // Works, but requires manual short-circuit logic at each step
+            var userId = await FindUserId("varmkorv");
+            var email = userId.IsSome()
+                ? await FindUserEmail(userId.Value())
+                : Option<string>.None();
+
+            Assert.Equal("varmkorv@example.com", email.Value());
+        }
+
+        [Fact]
+        public async Task Async_bind_enables_fluent_chaining()
+        {
+            var result = await FindUserId("varmkorv")
+                .BindAsync(FindUserEmail);
+
+            Assert.Equal("varmkorv@example.com", result.Value());
+        }
+
+        [Fact]
+        public async Task Async_bind_short_circuits_on_none()
+        {
+            var result = await FindUserId("unknown")
+                .BindAsync(FindUserEmail);
+
+            Assert.True(result.IsNone());
+        }
+
+        [Fact]
+        public async Task Async_map_transforms_value()
+        {
+            var result = await FindUserId("varmkorv")
+                .BindAsync(FindUserEmail)
+                .MapAsync(NormalizeEmail);
+
+            Assert.Equal("varmkorv@example.com", result.Value());
+        }
+
+        [Fact]
+        public async Task Async_chain_then_await_for_sync_operations()
+        {
+            // Async extensions for async callbacks, then await to
+            // use the full sync API for everything else
+            var greeting = (await FindUserId("varmkorv")
+                    .BindAsync(FindUserEmail))
+                .Map(email => $"Welcome, {email}!")
+                .DefaultWith(() => "Welcome, guest!");
+
+            Assert.Equal("Welcome, varmkorv@example.com!", greeting);
+        }
+    }
+}

--- a/tests/AsyncOptionTests.cs
+++ b/tests/AsyncOptionTests.cs
@@ -1,7 +1,6 @@
 using Xunit;
-using Svan.Monads;
 
-namespace Svan.Monads.UnitTest
+namespace Svan.Monads.UnitTests
 {
     public class AsyncOptionTests
     {
@@ -133,6 +132,18 @@ namespace Svan.Monads.UnitTest
                 .Sequence();
 
             Assert.True(result.IsNone());
+        }
+
+        [Fact]
+        public async Task Sequence_propagates_faulted_inner_task()
+        {
+            var option = Option<Task<string>>.Some(
+                Task.FromException<string>(new InvalidOperationException("faulted")));
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => option.Sequence());
+
+            Assert.Equal("faulted", ex.Message);
         }
     }
 }

--- a/tests/AsyncOptionTests.cs
+++ b/tests/AsyncOptionTests.cs
@@ -108,5 +108,31 @@ namespace Svan.Monads.UnitTest
 
             Assert.Equal("Welcome, varmkorv@example.com!", greeting);
         }
+
+        [Fact]
+        public async Task Sequence_enables_sync_map_with_async_function()
+        {
+            // When starting from a sync Option, Map with an async function
+            // produces Option<Task<T>>. Sequence flips it so we can await.
+            Option<string> email = Option<string>.Some("  VARMKORV@EXAMPLE.COM  ");
+
+            var result = await email
+                .Map(NormalizeEmail)
+                .Sequence();
+
+            Assert.Equal("varmkorv@example.com", result.Value());
+        }
+
+        [Fact]
+        public async Task Sequence_skips_the_async_work_on_none()
+        {
+            Option<string> email = Option<string>.None();
+
+            var result = await email
+                .Map(NormalizeEmail)
+                .Sequence();
+
+            Assert.True(result.IsNone());
+        }
     }
 }

--- a/tests/AsyncResultTests.cs
+++ b/tests/AsyncResultTests.cs
@@ -1,7 +1,6 @@
 using Xunit;
-using Svan.Monads;
 
-namespace Svan.Monads.UnitTest
+namespace Svan.Monads.UnitTests
 {
     public class AsyncResultTests
     {
@@ -141,6 +140,18 @@ namespace Svan.Monads.UnitTest
                 .Sequence();
 
             Assert.Equal("not found", result.ErrorValue());
+        }
+
+        [Fact]
+        public async Task Sequence_propagates_faulted_inner_task()
+        {
+            var result = Result<string, Task<string>>.Success(
+                Task.FromException<string>(new InvalidOperationException("faulted")));
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => result.Sequence());
+
+            Assert.Equal("faulted", ex.Message);
         }
     }
 }

--- a/tests/AsyncResultTests.cs
+++ b/tests/AsyncResultTests.cs
@@ -116,5 +116,32 @@ namespace Svan.Monads.UnitTest
 
             Assert.Equal("Welcome, varmkorv!", greeting);
         }
+
+        [Fact]
+        public async Task Sequence_enables_sync_map_with_async_function()
+        {
+            // When starting from a sync Result, Map with an async function
+            // produces Result<TError, Task<T>>. Sequence flips it so we can await.
+            Result<string, string> username = Result<string, string>.Success("varmkorv");
+
+            var result = await username
+                .Map(FormatGreeting)
+                .Sequence();
+
+            Assert.Equal("Hello, varmkorv!", result.SuccessValue());
+        }
+
+        [Fact]
+        public async Task Sequence_skips_the_async_work_on_error()
+        {
+            Result<string, string> username = Result<string, string>.Error("not found");
+
+            var result = await username
+                .Map(FormatGreeting)
+                .Sequence();
+
+            Assert.Equal("not found", result.ErrorValue());
+        }
     }
 }
+

--- a/tests/AsyncResultTests.cs
+++ b/tests/AsyncResultTests.cs
@@ -1,0 +1,120 @@
+using Xunit;
+using Svan.Monads;
+
+namespace Svan.Monads.UnitTest
+{
+    public class AsyncResultTests
+    {
+        // Simulated async services
+        private async Task<Result<string, int>> ParseUserId(string input)
+        {
+            await Task.Yield();
+            return int.TryParse(input, out var id)
+                ? Result<string, int>.Success(id)
+                : Result<string, int>.Error($"'{input}' is not a valid id");
+        }
+
+        private async Task<Result<string, string>> LookupUsername(int userId)
+        {
+            await Task.Yield();
+            return userId == 42
+                ? Result<string, string>.Success("varmkorv")
+                : Result<string, string>.Error($"user {userId} not found");
+        }
+
+        private async Task<string> FormatGreeting(string username)
+        {
+            await Task.Yield();
+            return $"Hello, {username}!";
+        }
+
+        [Fact]
+        public async Task Await_then_map_and_fold()
+        {
+            var result = (await ParseUserId("42"))
+                .Map(id => id * 2)
+                .Fold(error => -1, id => id);
+
+            Assert.Equal(84, result);
+        }
+
+        [Fact]
+        public async Task Await_then_fold_on_error()
+        {
+            var result = (await ParseUserId("abc"))
+                .Fold(
+                    error => error,
+                    id => "ok");
+
+            Assert.Equal("'abc' is not a valid id", result);
+        }
+
+        [Fact]
+        public async Task Await_then_default_with()
+        {
+            var result = (await ParseUserId("abc"))
+                .DefaultWith(error => -1);
+
+            Assert.Equal(-1, result);
+        }
+
+        [Fact]
+        public async Task Sequential_async_calls_with_intermediate_awaits()
+        {
+            var userId = await ParseUserId("42");
+            var username = userId.IsSuccess()
+                ? await LookupUsername(userId.SuccessValue())
+                : Result<string, string>.Error(userId.ErrorValue());
+
+            Assert.Equal("varmkorv", username.SuccessValue());
+        }
+
+        [Fact]
+        public async Task Async_bind_enables_fluent_chaining()
+        {
+            var result = await ParseUserId("42")
+                .BindAsync(LookupUsername);
+
+            Assert.Equal("varmkorv", result.SuccessValue());
+        }
+
+        [Fact]
+        public async Task Async_bind_short_circuits_on_error()
+        {
+            var result = await ParseUserId("abc")
+                .BindAsync(LookupUsername);
+
+            Assert.Equal("'abc' is not a valid id", result.ErrorValue());
+        }
+
+        [Fact]
+        public async Task Async_bind_propagates_second_error()
+        {
+            var result = await ParseUserId("99")
+                .BindAsync(LookupUsername);
+
+            Assert.Equal("user 99 not found", result.ErrorValue());
+        }
+
+        [Fact]
+        public async Task Async_map_transforms_value()
+        {
+            var result = await ParseUserId("42")
+                .BindAsync(LookupUsername)
+                .MapAsync(FormatGreeting);
+
+            Assert.Equal("Hello, varmkorv!", result.SuccessValue());
+        }
+
+        [Fact]
+        public async Task Async_chain_then_await_for_sync_operations()
+        {
+            var greeting = (await ParseUserId("42")
+                    .BindAsync(LookupUsername))
+                .Map(name => $"Welcome, {name}!")
+                .DefaultWith(error => $"Error: {error}");
+
+            Assert.Equal("Welcome, varmkorv!", greeting);
+        }
+    }
+}

--- a/tests/AsyncTryTests.cs
+++ b/tests/AsyncTryTests.cs
@@ -24,8 +24,6 @@ namespace Svan.Monads.UnitTest
             return $"result: {value}";
         }
 
-        // ── Already works today: await then chain sync operations ──
-
         [Fact]
         public async Task Await_then_map_and_fold()
         {
@@ -55,8 +53,6 @@ namespace Svan.Monads.UnitTest
 
             Assert.Equal(-1, result);
         }
-
-        // ── With two async extension methods: BindAsync and MapAsync ──
 
         [Fact]
         public async Task Async_bind_enables_fluent_chaining()
@@ -130,6 +126,92 @@ namespace Svan.Monads.UnitTest
                 .Sequence();
 
             Assert.Equal("boom", result.ErrorValue().Message);
+        }
+
+        // ── Catching variants: exceptions stay inside the monad ──
+
+        [Fact]
+        public void BindCatching_catches_exception_from_binder()
+        {
+            Try<int> value = Try.Catching(() => 10);
+
+            var result = value
+                .BindCatching<string>(n => throw new InvalidOperationException("binder failed"));
+
+            Assert.Equal("binder failed", result.ErrorValue().Message);
+        }
+
+        [Fact]
+        public async Task BindCatchingAsync_catches_exception_from_async_binder()
+        {
+            var result = await ParseNumber("10")
+                .BindCatchingAsync<int, string>(async n =>
+                {
+                    await Task.Yield();
+                    throw new InvalidOperationException("async binder failed");
+                });
+
+            Assert.Equal("async binder failed", result.ErrorValue().Message);
+        }
+
+        [Fact]
+        public async Task BindCatchingAsync_catches_faulted_task()
+        {
+            var result = await ParseNumber("10")
+                .BindCatchingAsync<int, string>(n =>
+                    Task.FromException<Try<string>>(new InvalidOperationException("faulted")));
+
+            Assert.Equal("faulted", result.ErrorValue().Message);
+        }
+
+        [Fact]
+        public async Task BindCatchingAsync_short_circuits_on_error()
+        {
+            var result = await ParseNumber("abc")
+                .BindCatchingAsync(SafeDivide);
+
+            Assert.True(result.IsError());
+        }
+
+        [Fact]
+        public async Task MapCatchingAsync_catches_exception_from_async_mapper()
+        {
+            var result = await ParseNumber("10")
+                .MapCatchingAsync<int, string>(async n =>
+                {
+                    await Task.Yield();
+                    throw new InvalidOperationException("async mapper failed");
+                });
+
+            Assert.Equal("async mapper failed", result.ErrorValue().Message);
+        }
+
+        [Fact]
+        public async Task MapCatchingAsync_catches_faulted_task()
+        {
+            var result = await ParseNumber("10")
+                .MapCatchingAsync<int, string>(n =>
+                    Task.FromException<string>(new InvalidOperationException("faulted")));
+
+            Assert.Equal("faulted", result.ErrorValue().Message);
+        }
+
+        [Fact]
+        public async Task MapCatchingAsync_returns_value_on_success()
+        {
+            var result = await ParseNumber("10")
+                .MapCatchingAsync(FormatResult);
+
+            Assert.Equal("result: 10", result.SuccessValue());
+        }
+
+        [Fact]
+        public async Task MapCatchingAsync_short_circuits_on_error()
+        {
+            var result = await ParseNumber("abc")
+                .MapCatchingAsync(FormatResult);
+
+            Assert.True(result.IsError());
         }
     }
 }

--- a/tests/AsyncTryTests.cs
+++ b/tests/AsyncTryTests.cs
@@ -1,0 +1,109 @@
+using Xunit;
+using Svan.Monads;
+
+namespace Svan.Monads.UnitTest
+{
+    public class AsyncTryTests
+    {
+        // Simulated async services
+        private async Task<Try<int>> ParseNumber(string input)
+        {
+            await Task.Yield();
+            return Try.Catching(() => int.Parse(input));
+        }
+
+        private async Task<Try<int>> SafeDivide(int value)
+        {
+            await Task.Yield();
+            return Try.Catching(() => 100 / value);
+        }
+
+        private async Task<string> FormatResult(int value)
+        {
+            await Task.Yield();
+            return $"result: {value}";
+        }
+
+        // ── Already works today: await then chain sync operations ──
+
+        [Fact]
+        public async Task Await_then_map_and_fold()
+        {
+            var result = (await ParseNumber("5"))
+                .Fold(error => -1, n => n * 2);
+
+            Assert.Equal(10, result);
+        }
+
+        [Fact]
+        public async Task Await_then_fold_on_error()
+        {
+            var result = (await ParseNumber("not a number"))
+                .Fold(
+                    error => error.Message,
+                    n => "ok");
+
+            Assert.Contains("not a number", result);
+        }
+
+        [Fact]
+        public async Task Await_then_default_with()
+        {
+            var result = (await ParseNumber("not a number"))
+                .DefaultWith(error => -1);
+
+            Assert.Equal(-1, result);
+        }
+
+        // ── With two async extension methods: BindAsync and MapAsync ──
+
+        [Fact]
+        public async Task Async_bind_enables_fluent_chaining()
+        {
+            var result = await ParseNumber("10")
+                .BindAsync(SafeDivide);
+
+            Assert.Equal(10, result.SuccessValue());
+        }
+
+        [Fact]
+        public async Task Async_bind_short_circuits_on_error()
+        {
+            var result = await ParseNumber("abc")
+                .BindAsync(SafeDivide);
+
+            Assert.True(result.IsError());
+        }
+
+        [Fact]
+        public async Task Async_bind_propagates_second_error()
+        {
+            var result = await ParseNumber("0")
+                .BindAsync(SafeDivide);
+
+            Assert.IsType<DivideByZeroException>(result.ErrorValue());
+        }
+
+        [Fact]
+        public async Task Async_map_transforms_value()
+        {
+            var result = await ParseNumber("10")
+                .BindAsync(SafeDivide)
+                .MapAsync(FormatResult);
+
+            Assert.Equal("result: 10", result.SuccessValue());
+        }
+
+        [Fact]
+        public async Task Async_chain_then_await_for_sync_operations()
+        {
+            var message = (await ParseNumber("10")
+                    .BindAsync(SafeDivide))
+                .Fold(
+                    error => $"failed: {error.Message}",
+                    n => $"computed: {n}");
+
+            Assert.Equal("computed: 10", message);
+        }
+    }
+}

--- a/tests/AsyncTryTests.cs
+++ b/tests/AsyncTryTests.cs
@@ -1,7 +1,6 @@
 using Xunit;
-using Svan.Monads;
 
-namespace Svan.Monads.UnitTest
+namespace Svan.Monads.UnitTests
 {
     public class AsyncTryTests
     {
@@ -128,7 +127,17 @@ namespace Svan.Monads.UnitTest
             Assert.Equal("boom", result.ErrorValue().Message);
         }
 
-        // ── Catching variants: exceptions stay inside the monad ──
+        [Fact]
+        public async Task Sequence_catches_faulted_inner_task()
+        {
+            Try<Task<string>> value = Try.Catching<Task<string>>(
+                () => Task.FromException<string>(new InvalidOperationException("faulted")));
+
+            var result = await value.Sequence();
+
+            Assert.True(result.IsError());
+            Assert.Equal("faulted", result.ErrorValue().Message);
+        }
 
         [Fact]
         public void BindCatching_catches_exception_from_binder()

--- a/tests/AsyncTryTests.cs
+++ b/tests/AsyncTryTests.cs
@@ -30,7 +30,8 @@ namespace Svan.Monads.UnitTest
         public async Task Await_then_map_and_fold()
         {
             var result = (await ParseNumber("5"))
-                .Fold(error => -1, n => n * 2);
+                .Map(n => n * 2)
+                .Fold(error => -1, n => n);
 
             Assert.Equal(10, result);
         }
@@ -99,9 +100,8 @@ namespace Svan.Monads.UnitTest
         {
             var message = (await ParseNumber("10")
                     .BindAsync(SafeDivide))
-                .Fold(
-                    error => $"failed: {error.Message}",
-                    n => $"computed: {n}");
+                .Map(n => $"computed: {n}")
+                .DefaultWith(error => $"failed: {error.Message}");
 
             Assert.Equal("computed: 10", message);
         }

--- a/tests/AsyncTryTests.cs
+++ b/tests/AsyncTryTests.cs
@@ -105,5 +105,31 @@ namespace Svan.Monads.UnitTest
 
             Assert.Equal("computed: 10", message);
         }
+ 
+        [Fact]
+        public async Task Sequence_enables_sync_map_with_async_function()
+        {
+            // When starting from a sync Try, Map with an async function
+            // produces Try<Task<T>>. Sequence flips it so we can await.
+            Try<int> value = Try.Catching(() => 10);
+
+            var result = await value
+                .Map(FormatResult)
+                .Sequence();
+
+            Assert.Equal("result: 10", result.SuccessValue());
+        }
+
+        [Fact]
+        public async Task Sequence_skips_the_async_work_on_error()
+        {
+            Try<int> value = Try.Catching<int>(() => throw new InvalidOperationException("boom"));
+
+            var result = await value
+                .Map(FormatResult)
+                .Sequence();
+
+            Assert.Equal("boom", result.ErrorValue().Message);
+        }
     }
 }

--- a/tests/OptionTests.cs
+++ b/tests/OptionTests.cs
@@ -1,303 +1,301 @@
 using Xunit;
-using Svan.Monads;
 
-namespace Svan.Monads.UnitTest
+namespace Svan.Monads.UnitTests;
+
+public class OptionTests
 {
-    public class OptionTests
+    private Option<int> IsGreaterThan10(int i)
     {
-        private Option<int> IsGreaterThan10(int i)
+        if (i > 10)
         {
-            if (i > 10)
-            {
-                return i;
-            }
-            else
-            {
-                return new None();
-            }
+            return i;
         }
-
-        private Option<int> IsEven(int i)
+        else
         {
-            if (i % 2 == 0)
-            {
-                return i;
-            }
-            else
-            {
-                return new None();
-            }
+            return new None();
         }
+    }
 
-        [Theory]
-        [InlineData(12)]
-        [InlineData(24)]
-        public void Conditional_execution_when_contract_is_fulfilled(int evenNumber)
+    private Option<int> IsEven(int i)
+    {
+        if (i % 2 == 0)
         {
-            var expected = evenNumber;
-            Option<int> option = evenNumber;
-
-            var actual = option
-                            .Bind(IsGreaterThan10)
-                            .Bind(IsEven)
-                            .Fold(
-                                () => 0,
-                                some => some);
-
-            Assert.Equal(expected, actual);
+            return i;
         }
-
-        [Theory]
-        [InlineData(5, "above two")]
-        [InlineData(1, "below or equal to two")]
-        public void Bind_to_different_data_type(int value, string expected)
+        else
         {
-            Option<int> option = value;
-
-            var actual = option
-                .Bind(i => i > 2
-                    ? Option<string>.Some("above two")
-                    : Option<string>.None())
-                .Fold(
-                    () => "below or equal to two",
-                    some => some);
-
-            Assert.Equal(expected, actual);
-
+            return new None();
         }
+    }
 
-        [Theory]
-        [InlineData(11)]
-        [InlineData(23)]
-        public void Conditional_execution_when_contract_is_not_fulfilled(int oddNumber)
-        {
-            var expected = 0;
-            Option<int> option = oddNumber;
+    [Theory]
+    [InlineData(12)]
+    [InlineData(24)]
+    public void Conditional_execution_when_contract_is_fulfilled(int evenNumber)
+    {
+        var expected = evenNumber;
+        Option<int> option = evenNumber;
 
-            var actual = option
-                            .Bind(IsGreaterThan10)
-                            .Bind(IsEven)
-                            .Fold(
-                                () => 0,
-                                some => some);
+        var actual = option
+            .Bind(IsGreaterThan10)
+            .Bind(IsEven)
+            .Fold(
+                () => 0,
+                some => some);
 
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void Convert_to_option_type_using_map()
-        {
-            var expected = "~20~";
-            Option<int> option = 20;
+    [Theory]
+    [InlineData(5, "above two")]
+    [InlineData(1, "below or equal to two")]
+    public void Bind_to_different_data_type(int value, string expected)
+    {
+        Option<int> option = value;
 
-            var actual = option
-                            .Bind(IsGreaterThan10)
-                            .Bind(IsEven)
-                            .Map(i => i.ToString())
-                            .Map(s => $"~{s}~")
-                            .Fold(
-                                () => "could not convert number",
-                                some => some);
+        var actual = option
+            .Bind(i => i > 2
+                ? Option<string>.Some("above two")
+                : Option<string>.None())
+            .Fold(
+                () => "below or equal to two",
+                some => some);
 
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
 
-        [Fact]
-        public void Pipeline_does_not_break_on_None()
-        {
-            var expected = "could not convert number";
-            Option<int> option = 19;
+    }
 
-            var actual = option
-                            .Bind(IsGreaterThan10)
-                            .Bind(IsEven)
-                            .Map(i => i.ToString())
-                            .Map(s => $"~{s}~")
-                            .Fold(
-                                () => "could not convert number",
-                                some => some);
+    [Theory]
+    [InlineData(11)]
+    [InlineData(23)]
+    public void Conditional_execution_when_contract_is_not_fulfilled(int oddNumber)
+    {
+        var expected = 0;
+        Option<int> option = oddNumber;
 
-            Assert.Equal(expected, actual);
-        }
+        var actual = option
+            .Bind(IsGreaterThan10)
+            .Bind(IsEven)
+            .Fold(
+                () => 0,
+                some => some);
 
-        [Fact]
-        public void Use_filter_to_get_conditional_result()
-        {
-            var expected = 5;
-            Option<int> option = 5;
-            var actual = option
-                .Filter(i => i > 0)
-                .Filter(i => i % 2 > 0)
-                .Match(
-                    none => 0,
-                    some => some.Value);
+        Assert.Equal(expected, actual);
+    }
 
-            Assert.Equal(expected, actual);
+    [Fact]
+    public void Convert_to_option_type_using_map()
+    {
+        var expected = "~20~";
+        Option<int> option = 20;
 
-            expected = 0;
-            option = Option<int>.Some(4);
-            actual = option
-                .Filter(i => i > 0)
-                .Filter(i => i % 2 > 0)
-                .Match(
-                    none => 0,
-                    some => some.Value);
+        var actual = option
+            .Bind(IsGreaterThan10)
+            .Bind(IsEven)
+            .Map(i => i.ToString())
+            .Map(s => $"~{s}~")
+            .Fold(
+                () => "could not convert number",
+                some => some);
 
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void Use_Do_to_execute_conditional_actions()
-        {
-            Option<int> option = 5;
+    [Fact]
+    public void Pipeline_does_not_break_on_None()
+    {
+        var expected = "could not convert number";
+        Option<int> option = 19;
 
-            option
-                .DoIfNone(() => Assert.Fail("this should not be executed"))
-                .Do(i => Assert.Equal(5, i));
-        }
+        var actual = option
+            .Bind(IsGreaterThan10)
+            .Bind(IsEven)
+            .Map(i => i.ToString())
+            .Map(s => $"~{s}~")
+            .Fold(
+                () => "could not convert number",
+                some => some);
 
-        [Fact]
-        public void Use_DoIfNone_to_execute_conditional_actions()
-        {
-            Option<int> option = new None();
+        Assert.Equal(expected, actual);
+    }
 
-            option
-                .Do(i => Assert.Fail("this should not be executed"))
-                .DoIfNone(() => Assert.True(true, "this should be executed"));
-        }
+    [Fact]
+    public void Use_filter_to_get_conditional_result()
+    {
+        var expected = 5;
+        Option<int> option = 5;
+        var actual = option
+            .Filter(i => i > 0)
+            .Filter(i => i % 2 > 0)
+            .Match(
+                none => 0,
+                some => some.Value);
 
-        [Fact]
-        public void ToOption_should_return_Some_for_value_types()
-        {
-            int i = default;
-            i.ToOption()
-                .Switch(
-                    none => Assert.Fail("should not be None"),
-                    some => Assert.True(true, "should be Some<int>"));
+        Assert.Equal(expected, actual);
 
-            i = 5;
-            i.ToOption()
-                .Switch(
-                    none => Assert.Fail("should not be None"),
-                    some => Assert.True(true, "should be Some<int>"));
-        }
+        expected = 0;
+        option = Option<int>.Some(4);
+        actual = option
+            .Filter(i => i > 0)
+            .Filter(i => i % 2 > 0)
+            .Match(
+                none => 0,
+                some => some.Value);
 
-        [Fact]
-        public void ToOption_should_return_Some_or_None_for_reference_types()
-        {
-            TestClass t = default;
-            t.ToOption()
-                .Switch(
-                    none => Assert.True(true, "should be None"),
-                    some => Assert.Fail("should not be Some<TestClass>"));
+        Assert.Equal(expected, actual);
+    }
 
-            t = new TestClass();
-            t.ToOption()
-                .Switch(
-                    none => Assert.Fail("should not be None"),
-                    some => Assert.True(true, "should be Some<TestClass>"));
-        }
+    [Fact]
+    public void Use_Do_to_execute_conditional_actions()
+    {
+        Option<int> option = 5;
 
-        [Fact]
-        public void Combine_options_with_zip_when_all_are_some()
-        {
-            var option1 = 5.ToOption();
-            var option2 = 8.ToOption();
-            var expected = 13;
+        option
+            .DoIfNone(() => Assert.Fail("this should not be executed"))
+            .Do(i => Assert.Equal(5, i));
+    }
 
-            var actual = option1
-                .Zip(option2, (value1, value2) => value1 + value2)
-                .DefaultWith(() => 0);
+    [Fact]
+    public void Use_DoIfNone_to_execute_conditional_actions()
+    {
+        Option<int> option = new None();
 
-            Assert.Equal(expected, actual);
-        }
+        option
+            .Do(i => Assert.Fail("this should not be executed"))
+            .DoIfNone(() => Assert.True(true, "this should be executed"));
+    }
 
-        [Fact]
-        public void Combine_options_with_zip_when_none()
-        {
-            var option1 = 5.ToOption();
-            var option2 = Option<string>.None();
-            var expected = "this should happen";
+    [Fact]
+    public void ToOption_should_return_Some_for_value_types()
+    {
+        int i = default;
+        i.ToOption()
+            .Switch(
+                none => Assert.Fail("should not be None"),
+                some => Assert.True(true, "should be Some<int>"));
 
-            var actual = option1
-                .Zip(option2, (value1, value2) => "this should not happen")
-                .DefaultWith(() => "this should happen");
+        i = 5;
+        i.ToOption()
+            .Switch(
+                none => Assert.Fail("should not be None"),
+                some => Assert.True(true, "should be Some<int>"));
+    }
 
-            Assert.Equal(expected, actual);
-        }
+    [Fact]
+    public void ToOption_should_return_Some_or_None_for_reference_types()
+    {
+        TestClass t = default;
+        t.ToOption()
+            .Switch(
+                none => Assert.True(true, "should be None"),
+                some => Assert.Fail("should not be Some<TestClass>"));
 
-        [Fact]
-        public void Combine_five_options_with_zip_when_all_are_some()
-        {
-            var option1 = 1.ToOption();
-            var option2 = 2.ToOption();
-            var option3 = 3.ToOption();
-            var option4 = 4.ToOption();
-            var option5 = 5.ToOption();
+        t = new TestClass();
+        t.ToOption()
+            .Switch(
+                none => Assert.Fail("should not be None"),
+                some => Assert.True(true, "should be Some<TestClass>"));
+    }
 
-            var expected = 1 + 2 + 3 + 4 + 5;
+    [Fact]
+    public void Combine_options_with_zip_when_all_are_some()
+    {
+        var option1 = 5.ToOption();
+        var option2 = 8.ToOption();
+        var expected = 13;
 
-            var actual = option1
-                .Zip(
-                    option2,
-                    option3,
-                    option4,
-                    option5,
-                    (value1, value2, value3, value4, value5)
-                        => value1 + value2 + value3 + value4 + value5)
-                .DefaultWith(() => 0);
+        var actual = option1
+            .Zip(option2, (value1, value2) => value1 + value2)
+            .DefaultWith(() => 0);
 
-            Assert.Equal(expected, actual);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void Merge_can_combine_options()
-        {
-            var expected = 10 + 20 + 30 + 40 + 50;
+    [Fact]
+    public void Combine_options_with_zip_when_none()
+    {
+        var option1 = 5.ToOption();
+        var option2 = Option<string>.None();
+        var expected = "this should happen";
 
-            var result = 10.ToOption()
-                .Merge(20.ToOption())
-                .Merge(30.ToOption())
-                .Merge(40.ToOption())
-                .Merge(50.ToOption())
-                .Fold(
-                    () => 0,
-                    (group) => group.Item1 + group.Item2 + group.Item3 + group.Item4 + group.Item5);
+        var actual = option1
+            .Zip(option2, (value1, value2) => "this should not happen")
+            .DefaultWith(() => "this should happen");
 
-            Assert.Equal(expected, result);
-        }
+        Assert.Equal(expected, actual);
+    }
 
-        [Fact]
-        public void ToResult_converts_an_option_to_a_successful_result()
-        {
-            var option = Option<int>.Some(111);
-            var result = option.ToResult(() => new System.Exception("hello"));
+    [Fact]
+    public void Combine_five_options_with_zip_when_all_are_some()
+    {
+        var option1 = 1.ToOption();
+        var option2 = 2.ToOption();
+        var option3 = 3.ToOption();
+        var option4 = 4.ToOption();
+        var option5 = 5.ToOption();
 
-            Assert.Equal(111, result.SuccessValue());
-        }
+        var expected = 1 + 2 + 3 + 4 + 5;
 
-        [Fact]
-        public void ToResult_converts_an_option_to_an_error_result()
-        {
-            var option = Option<int>.None();
-            var result = option.ToResult(() => new System.Exception("hello"));
+        var actual = option1
+            .Zip(
+                option2,
+                option3,
+                option4,
+                option5,
+                (value1, value2, value3, value4, value5)
+                    => value1 + value2 + value3 + value4 + value5)
+            .DefaultWith(() => 0);
 
-            Assert.Equal("hello", result.ErrorValue().Message);
-        }
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void Merge_can_combine_options()
+    {
+        var expected = 10 + 20 + 30 + 40 + 50;
+
+        var result = 10.ToOption()
+            .Merge(20.ToOption())
+            .Merge(30.ToOption())
+            .Merge(40.ToOption())
+            .Merge(50.ToOption())
+            .Fold(
+                () => 0,
+                (group) => group.Item1 + group.Item2 + group.Item3 + group.Item4 + group.Item5);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ToResult_converts_an_option_to_a_successful_result()
+    {
+        var option = Option<int>.Some(111);
+        var result = option.ToResult(() => new System.Exception("hello"));
+
+        Assert.Equal(111, result.SuccessValue());
+    }
+
+    [Fact]
+    public void ToResult_converts_an_option_to_an_error_result()
+    {
+        var option = Option<int>.None();
+        var result = option.ToResult(() => new System.Exception("hello"));
+
+        Assert.Equal("hello", result.ErrorValue().Message);
+    }
         
-        [Fact]
-        public void OrThrow_throws_A_null_reference_exception()
-        {
-            var optionNone = Option<int>.None();
-            Assert.Throws<NullReferenceException>(() => optionNone.OrThrow());
+    [Fact]
+    public void OrThrow_throws_A_null_reference_exception()
+    {
+        var optionNone = Option<int>.None();
+        Assert.Throws<NullReferenceException>(() => optionNone.OrThrow());
             
-            var optionSome = Option<int>.Some(1);
-            Assert.Equal(1, optionSome.OrThrow());
-        }
+        var optionSome = Option<int>.Some(1);
+        Assert.Equal(1, optionSome.OrThrow());
+    }
 
-        class TestClass
-        {
+    class TestClass
+    {
 
-        }
     }
 }

--- a/tests/ResultTests.cs
+++ b/tests/ResultTests.cs
@@ -1,8 +1,6 @@
 using Xunit;
-using Svan.Monads;
 using OneOf.Types;
 using OneOf;
-using System;
 
 namespace Svan.Monads.UnitTests
 {

--- a/tests/TryTests.cs
+++ b/tests/TryTests.cs
@@ -1,7 +1,4 @@
 using Xunit;
-using Svan.Monads;
-using OneOf.Types;
-using System;
 
 namespace Svan.Monads.UnitTests
 {

--- a/tests/TryTests.cs
+++ b/tests/TryTests.cs
@@ -34,6 +34,49 @@ namespace Svan.Monads.UnitTests
                 .Do((value) => Assert.True(false));
         }
 
+        [Fact]
+        public void BindCatching_catches_exception_from_binder()
+        {
+            var result = Try.Catching(() => 42)
+                .BindCatching<string>(n => throw new ArgumentException("binder threw"));
+
+            Assert.Equal("binder threw", result.ErrorValue().Message);
+        }
+
+        [Fact]
+        public void BindCatching_returns_value_on_success()
+        {
+            var result = Try.Catching(() => 42)
+                .BindCatching(n => Try.Catching(() => $"value: {n}"));
+
+            Assert.Equal("value: 42", result.SuccessValue());
+        }
+
+        [Fact]
+        public void BindCatching_short_circuits_on_error()
+        {
+            var executed = false;
+
+            var result = Try.Catching<int>(() => throw new Exception("initial error"))
+                .BindCatching(n =>
+                {
+                    executed = true;
+                    return Try.Catching(() => n * 2);
+                });
+
+            Assert.False(executed);
+            Assert.Equal("initial error", result.ErrorValue().Message);
+        }
+
+        [Fact]
+        public void BindCatching_propagates_error_from_binder_result()
+        {
+            var result = Try.Catching(() => 42)
+                .BindCatching<string>(n => new Exception("binder returned error"));
+
+            Assert.Equal("binder returned error", result.ErrorValue().Message);
+        }
+
         class ErrorThatIsNotAnExceptionType { }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0",
+  "version": "1.31",
   "publicReleaseRefSpec": ["^refs/heads/main$"]
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.30",
+  "version": "2.0",
   "publicReleaseRefSpec": ["^refs/heads/main$"]
 }


### PR DESCRIPTION
As per request in issue #2 

- `BindAsync` / `MapAsync` on `Task<Option<T>>`, `Task<Result<TError, T>>`, and `Task<Try<T>>` — for fluent chaining when the callback itself is async
- Sequence on `Option<Task<T>>`, `Result<TError, Task<T>>`, and `Try<Task<T>>` — flips the inner task out so a sync monad mapped with an async function becomes awaitable
- Bug fix in `Try<T>`: All overridden methods (`Map`, `Bind`, `Do`, `DoIfError`, `Zip`) used `base.X() as Try<T>` which returned `null` because the base Result constructs Result instances, not Try. Reimplemented properly.
- README: New Async Support section with code examples
- Add XML docs where it was missing
- New tests covering all async extensions across Option, Result, and Try

Design rationale

Only 3 extension methods per monad type (`BindAsync`, `MapAsync`, `Sequence`) instead of mirroring the full API. All sync operations (`Filter`, `Fold`, `DefaultWith`, `Do`, `Zip`, etc.) work naturally after an await.