### PR TITLE
Add Either monad

### DIFF
--- a/src/Either/AsyncEitherExtensions.cs
+++ b/src/Either/AsyncEitherExtensions.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Svan.Monads
+{
+    public static class AsyncEitherExtensions
+    {
+        /// <summary>
+        /// Flips an <c>Either&lt;TLeft, Task&lt;TRight&gt;&gt;</c> into a <c>Task&lt;Either&lt;TLeft, TRight&gt;&gt;</c>.
+        /// Awaits the inner task when <c>Right</c>, returns the left value immediately when <c>Left</c>.
+        /// </summary>
+        public static async Task<Either<TLeft, TRight>> Sequence<TLeft, TRight>(
+            this Either<TLeft, Task<TRight>> eitherTask)
+        {
+            if (eitherTask.IsLeft)
+            {
+                return Either<TLeft, TRight>.FromLeft(eitherTask.LeftValue());
+            }
+
+            var value = await eitherTask.RightValue().ConfigureAwait(false);
+            return Either<TLeft, TRight>.FromRight(value);
+        }
+
+        /// <summary>
+        /// Binds an async function over a <c>Task&lt;Either&lt;TLeft, TRight&gt;&gt;</c>.
+        /// The binder is only called when the either is <c>Right</c>; otherwise short-circuits with the existing left value.
+        /// </summary>
+        public static async Task<Either<TLeft, TOut>> BindAsync<TLeft, TRight, TOut>(
+            this Task<Either<TLeft, TRight>> eitherTask,
+            Func<TRight, Task<Either<TLeft, TOut>>> binder)
+        {
+            var either = await eitherTask.ConfigureAwait(false);
+            return either.IsRight
+                ? await binder(either.RightValue()).ConfigureAwait(false)
+                : Either<TLeft, TOut>.FromLeft(either.LeftValue());
+        }
+
+        /// <summary>
+        /// Maps an async function over a <c>Task&lt;Either&lt;TLeft, TRight&gt;&gt;</c>.
+        /// The mapper is only called when the either is <c>Right</c>; otherwise short-circuits with the existing left value.
+        /// </summary>
+        public static async Task<Either<TLeft, TOut>> MapAsync<TLeft, TRight, TOut>(
+            this Task<Either<TLeft, TRight>> eitherTask,
+            Func<TRight, Task<TOut>> mapper)
+        {
+            var either = await eitherTask.ConfigureAwait(false);
+            return either.IsRight
+                ? Either<TLeft, TOut>.FromRight(await mapper(either.RightValue()).ConfigureAwait(false))
+                : Either<TLeft, TOut>.FromLeft(either.LeftValue());
+        }
+    }
+}

--- a/src/Either/Either.cs
+++ b/src/Either/Either.cs
@@ -1,0 +1,177 @@
+using System;
+
+namespace Svan.Monads
+{
+    /// <summary>
+    /// A general-purpose discriminated union where both sides carry meaning.
+    /// Right-biased for chainable pipelines, without the opinionated error/success semantics of <see cref="Result{TError, TSuccess}"/>.
+    /// </summary>
+    public class Either<TLeft, TRight> : Union<TLeft, TRight>
+    {
+        internal Either(Left<TLeft> value) : base(value) { }
+        internal Either(Right<TRight> value) : base(value) { }
+
+        public static Either<TLeft, TRight> FromLeft(TLeft value) => new(new Left<TLeft>(value));
+        public static Either<TLeft, TRight> FromRight(TRight value) => new(new Right<TRight>(value));
+
+        /// <summary>
+        /// Returns the left value. Throws <see cref="NullReferenceException"/> if the value is Right.
+        /// </summary>
+        public TLeft LeftValue() => IsLeft ? AsLeft : throw new NullReferenceException("Cannot access Left when value is Right.");
+
+        /// <summary>
+        /// Returns the right value. Throws <see cref="NullReferenceException"/> if the value is Left.
+        /// </summary>
+        public TRight RightValue() => IsRight ? AsRight : throw new NullReferenceException("Cannot access Right when value is Left.");
+
+        /// <summary>
+        /// Map the right value to a new type. Short-circuits on Left.
+        /// </summary>
+        public Either<TLeft, TOut> Map<TOut>(Func<TRight, TOut> map)
+            => Match(Either<TLeft, TOut>.FromLeft, r => Either<TLeft, TOut>.FromRight(map(r)));
+
+        /// <summary>
+        /// Bind the right value to a new <c>Either&lt;TLeft, TOut&gt;</c>. Short-circuits on Left.
+        /// </summary>
+        public Either<TLeft, TOut> Bind<TOut>(Func<TRight, Either<TLeft, TOut>> binder)
+            => Match(Either<TLeft, TOut>.FromLeft, binder);
+
+        /// <summary>
+        /// Execute an action on the right value. Returns the current Either unchanged.
+        /// </summary>
+        public Either<TLeft, TRight> Do(Action<TRight> @do)
+        {
+            if (IsRight)
+            {
+                @do(RightValue());
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Get the right value or a fallback derived from the left value.
+        /// </summary>
+        public TRight DefaultWith(Func<TLeft, TRight> fallback) => Match(fallback, r => r);
+
+        /// <summary>
+        /// Get the right value or a fallback value.
+        /// </summary>
+        public TRight DefaultWith(TRight fallback) => Match(_ => fallback, r => r);
+
+        /// <summary>
+        /// Get the right value or throw an <see cref="InvalidOperationException"/>.
+        /// </summary>
+        public TRight OrThrow()
+            => Match(
+                l => throw new InvalidOperationException($"Expected a right value of {typeof(TRight).Name} but was left: {l}."),
+                r => r);
+
+        /// <summary>
+        /// Map the left value to a new type. Short-circuits on Right.
+        /// </summary>
+        public Either<TOut, TRight> MapLeft<TOut>(Func<TLeft, TOut> map)
+            => Match(l => Either<TOut, TRight>.FromLeft(map(l)), Either<TOut, TRight>.FromRight);
+
+        /// <summary>
+        /// Bind the left value to a new <c>Either&lt;TOut, TRight&gt;</c>. Short-circuits on Right.
+        /// </summary>
+        public Either<TOut, TRight> BindLeft<TOut>(Func<TLeft, Either<TOut, TRight>> binder)
+            => Match(binder, Either<TOut, TRight>.FromRight);
+
+        /// <summary>
+        /// Execute an action on the left value. Returns the current Either unchanged.
+        /// </summary>
+        public Either<TLeft, TRight> DoIfLeft(Action<TLeft> @do)
+        {
+            if (IsLeft)
+            {
+                @do(LeftValue());
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Fold into a value of type <c>TOut</c> with supplied functions for each case.
+        /// </summary>
+        public TOut Fold<TOut>(Func<TLeft, TOut> caseLeft, Func<TRight, TOut> caseRight)
+            => Match(caseLeft, caseRight);
+
+        /// <summary>
+        /// Swap left and right sides.
+        /// </summary>
+        public Either<TRight, TLeft> Swap()
+            => Match(Either<TRight, TLeft>.FromRight, Either<TRight, TLeft>.FromLeft);
+
+        /// <summary>
+        /// Combine two eithers into a new right value using a combine function. Returns first Left encountered.
+        /// </summary>
+        public Either<TLeft, TOut> Zip<TOut, TOther>(
+            Either<TLeft, TOther> other,
+            Func<TRight, TOther, TOut> combine)
+        {
+            if (IsLeft) return Either<TLeft, TOut>.FromLeft(LeftValue());
+            if (other.IsLeft) return Either<TLeft, TOut>.FromLeft(other.LeftValue());
+            return Either<TLeft, TOut>.FromRight(combine(RightValue(), other.RightValue()));
+        }
+
+        /// <summary>
+        /// Combine three eithers into a new right value using a combine function. Returns first Left encountered.
+        /// </summary>
+        public Either<TLeft, TOut> Zip<TOut, TFirstOther, TSecondOther>(
+            Either<TLeft, TFirstOther> firstOther,
+            Either<TLeft, TSecondOther> secondOther,
+            Func<TRight, TFirstOther, TSecondOther, TOut> combine)
+        {
+            if (IsLeft) return Either<TLeft, TOut>.FromLeft(LeftValue());
+            if (firstOther.IsLeft) return Either<TLeft, TOut>.FromLeft(firstOther.LeftValue());
+            if (secondOther.IsLeft) return Either<TLeft, TOut>.FromLeft(secondOther.LeftValue());
+            return Either<TLeft, TOut>.FromRight(combine(RightValue(), firstOther.RightValue(), secondOther.RightValue()));
+        }
+
+        /// <summary>
+        /// Combine four eithers into a new right value using a combine function. Returns first Left encountered.
+        /// </summary>
+        public Either<TLeft, TOut> Zip<TOut, TFirstOther, TSecondOther, TThirdOther>(
+            Either<TLeft, TFirstOther> firstOther,
+            Either<TLeft, TSecondOther> secondOther,
+            Either<TLeft, TThirdOther> thirdOther,
+            Func<TRight, TFirstOther, TSecondOther, TThirdOther, TOut> combine)
+        {
+            if (IsLeft) return Either<TLeft, TOut>.FromLeft(LeftValue());
+            if (firstOther.IsLeft) return Either<TLeft, TOut>.FromLeft(firstOther.LeftValue());
+            if (secondOther.IsLeft) return Either<TLeft, TOut>.FromLeft(secondOther.LeftValue());
+            if (thirdOther.IsLeft) return Either<TLeft, TOut>.FromLeft(thirdOther.LeftValue());
+            return Either<TLeft, TOut>.FromRight(combine(RightValue(), firstOther.RightValue(), secondOther.RightValue(), thirdOther.RightValue()));
+        }
+
+        /// <summary>
+        /// Combine five eithers into a new right value using a combine function. Returns first Left encountered.
+        /// </summary>
+        public Either<TLeft, TOut> Zip<TOut, TFirstOther, TSecondOther, TThirdOther, TFourthOther>(
+            Either<TLeft, TFirstOther> firstOther,
+            Either<TLeft, TSecondOther> secondOther,
+            Either<TLeft, TThirdOther> thirdOther,
+            Either<TLeft, TFourthOther> fourthOther,
+            Func<TRight, TFirstOther, TSecondOther, TThirdOther, TFourthOther, TOut> combine)
+        {
+            if (IsLeft) return Either<TLeft, TOut>.FromLeft(LeftValue());
+            if (firstOther.IsLeft) return Either<TLeft, TOut>.FromLeft(firstOther.LeftValue());
+            if (secondOther.IsLeft) return Either<TLeft, TOut>.FromLeft(secondOther.LeftValue());
+            if (thirdOther.IsLeft) return Either<TLeft, TOut>.FromLeft(thirdOther.LeftValue());
+            if (fourthOther.IsLeft) return Either<TLeft, TOut>.FromLeft(fourthOther.LeftValue());
+            return Either<TLeft, TOut>.FromRight(combine(RightValue(), firstOther.RightValue(), secondOther.RightValue(), thirdOther.RightValue(), fourthOther.RightValue()));
+        }
+
+        /// <summary>
+        /// Convert to <see cref="Option{TRight}"/>. Left becomes None, Right becomes Some.
+        /// </summary>
+        public Option<TRight> ToOption() => Match(_ => Option<TRight>.None(), Option<TRight>.Some);
+
+        /// <summary>
+        /// Convert to <see cref="Result{TLeft, TRight}"/>. Left becomes Error, Right becomes Success.
+        /// </summary>
+        public Result<TLeft, TRight> ToResult() => Match(Result<TLeft, TRight>.Error, Result<TLeft, TRight>.Success);
+    }
+}

--- a/src/Either/EitherConstructors.cs
+++ b/src/Either/EitherConstructors.cs
@@ -1,10 +1,23 @@
-namespace Svan.Monads
+namespace Svan.Monads;
+
+public static class Either
 {
-    public static class Either
-    {
-        public static Either<TLeft, TRight> FromLeft<TLeft, TRight>(TLeft value) => Either<TLeft, TRight>.FromLeft(value);
-        public static Either<TLeft, TRight> FromRight<TLeft, TRight>(TRight value) => Either<TLeft, TRight>.FromRight(value);
-        public static Either<TLeft, TRight> ToLeft<TLeft, TRight>(this TLeft value) => FromLeft<TLeft, TRight>(value);
-        public static Either<TLeft, TRight> ToRight<TLeft, TRight>(this TRight value) => FromRight<TLeft, TRight>(value);
-    }
+    /// <summary>
+    /// Creates an <c>Either</c> (left) with the provided value.
+    /// </summary>
+    public static Either<TLeft, TRight> FromLeft<TLeft, TRight>(TLeft value) => Either<TLeft, TRight>.FromLeft(value);
+    /// <summary>
+    /// Creates an <c>Either</c> (right) with the provided value.
+    /// </summary>
+    public static Either<TLeft, TRight> FromRight<TLeft, TRight>(TRight value) => Either<TLeft, TRight>.FromRight(value);
+
+    /// <summary>
+    /// Creates an <c>Either</c> (left) with the provided value.
+    /// </summary>
+    public static Either<TLeft, TRight> ToLeft<TLeft, TRight>(this TLeft value) => FromLeft<TLeft, TRight>(value);
+    /// <summary>
+    /// Creates an <c>Either</c> (right) with the provided value.
+    /// </summary>
+    public static Either<TLeft, TRight> ToRight<TLeft, TRight>(this TRight value) => FromRight<TLeft, TRight>(value);
 }
+

--- a/src/Either/EitherConstructors.cs
+++ b/src/Either/EitherConstructors.cs
@@ -1,0 +1,10 @@
+namespace Svan.Monads
+{
+    public static class Either
+    {
+        public static Either<TLeft, TRight> FromLeft<TLeft, TRight>(TLeft value) => Either<TLeft, TRight>.FromLeft(value);
+        public static Either<TLeft, TRight> FromRight<TLeft, TRight>(TRight value) => Either<TLeft, TRight>.FromRight(value);
+        public static Either<TLeft, TRight> ToLeft<TLeft, TRight>(this TLeft value) => FromLeft<TLeft, TRight>(value);
+        public static Either<TLeft, TRight> ToRight<TLeft, TRight>(this TRight value) => FromRight<TLeft, TRight>(value);
+    }
+}

--- a/src/Either/EitherExtensions.cs
+++ b/src/Either/EitherExtensions.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+
+namespace Svan.Monads
+{
+    public static class EitherExtensions
+    {
+        /// <summary>
+        /// Merge two eithers together. Only merges if both are Right.
+        /// </summary>
+        public static Either<TLeft, Tuple<TFirst, TSecond>> Merge<TLeft, TFirst, TSecond>(
+            this Either<TLeft, TFirst> first, Either<TLeft, TSecond> second) =>
+                first.Zip(second, (f, s) => new Tuple<TFirst, TSecond>(f, s));
+
+        /// <summary>
+        /// Merge a third either into an existing merged pair. Only merges if all are Right.
+        /// </summary>
+        public static Either<TLeft, Tuple<TFirst, TSecond, TThird>> Merge<TLeft, TFirst, TSecond, TThird>(
+            this Either<TLeft, Tuple<TFirst, TSecond>> group, Either<TLeft, TThird> other) =>
+                group.Zip(other, (g, o) => new Tuple<TFirst, TSecond, TThird>(g.Item1, g.Item2, o));
+
+        /// <summary>
+        /// Merge a fourth either into an existing merged triple. Only merges if all are Right.
+        /// </summary>
+        public static Either<TLeft, Tuple<TFirst, TSecond, TThird, TFourth>> Merge<TLeft, TFirst, TSecond, TThird, TFourth>(
+            this Either<TLeft, Tuple<TFirst, TSecond, TThird>> group, Either<TLeft, TFourth> other) =>
+                group.Zip(other, (g, o) => new Tuple<TFirst, TSecond, TThird, TFourth>(g.Item1, g.Item2, g.Item3, o));
+
+        /// <summary>
+        /// Merge a fifth either into an existing merged quad. Only merges if all are Right.
+        /// </summary>
+        public static Either<TLeft, Tuple<TFirst, TSecond, TThird, TFourth, TFifth>> Merge<TLeft, TFirst, TSecond, TThird, TFourth, TFifth>(
+            this Either<TLeft, Tuple<TFirst, TSecond, TThird, TFourth>> group, Either<TLeft, TFifth> other) =>
+                group.Zip(other, (g, o) => new Tuple<TFirst, TSecond, TThird, TFourth, TFifth>(g.Item1, g.Item2, g.Item3, g.Item4, o));
+
+        /// <summary>
+        /// Combine a sequence of eithers. Returns Right with all values if every either is Right,
+        /// or the first Left encountered.
+        /// </summary>
+        public static Either<TLeft, IEnumerable<TRight>> Sequence<TLeft, TRight>(
+            this IEnumerable<Either<TLeft, TRight>> eithers)
+        {
+            var values = new List<TRight>();
+
+            foreach (var either in eithers)
+            {
+                if (either.IsLeft)
+                {
+                    return Either<TLeft, IEnumerable<TRight>>.FromLeft(either.LeftValue());
+                }
+
+                values.Add(either.RightValue());
+            }
+
+            return Either<TLeft, IEnumerable<TRight>>.FromRight(values);
+        }
+
+        /// <summary>
+        /// Flattens a nested <c>Either&lt;TLeft, Either&lt;TLeft, TRight&gt;&gt;</c> into an <c>Either&lt;TLeft, TRight&gt;</c>.
+        /// Returns the inner either when Right, or propagates the outer Left.
+        /// </summary>
+        public static Either<TLeft, TRight> Flatten<TLeft, TRight>(
+            this Either<TLeft, Either<TLeft, TRight>> either)
+            => either.DefaultWith(Either<TLeft, TRight>.FromLeft);
+    }
+}

--- a/src/Option/Option.cs
+++ b/src/Option/Option.cs
@@ -104,7 +104,7 @@ namespace Svan.Monads
             => Fold(
                 defaultNone,
                 value => value);
-        
+
         /// <summary>
         /// Get the value of <c>Some</c> or a default value from the supplied function.
         /// </summary>
@@ -112,7 +112,7 @@ namespace Svan.Monads
             => Fold(
                 () => defaultNone,
                 value => value);
-        
+
         /// <summary>
         /// Get the value of <c>Some</c> or throw a <see cref="NullReferenceException"/>.
         /// </summary>

--- a/src/Result/Result.cs
+++ b/src/Result/Result.cs
@@ -106,7 +106,7 @@ namespace Svan.Monads
         /// </summary>
         public TSuccess DefaultWith(Func<TError, TSuccess> fallback)
             => Match(fallback, success => success);
-        
+
         /// <summary>
         /// Get the value of <c>TSuccess</c> or a default value from the supplied value.
         /// </summary>

--- a/tests/AsyncEitherTests.cs
+++ b/tests/AsyncEitherTests.cs
@@ -1,0 +1,144 @@
+using Xunit;
+
+namespace Svan.Monads.UnitTests
+{
+    public class AsyncEitherTests
+    {
+        // Simulated async services
+        private async Task<Either<string, int>> ParseId(string input)
+        {
+            await Task.Yield();
+            return int.TryParse(input, out var id)
+                ? Either<string, int>.FromRight(id)
+                : Either<string, int>.FromLeft($"'{input}' is not a valid id");
+        }
+
+        private async Task<Either<string, string>> LookupName(int id)
+        {
+            await Task.Yield();
+            return id == 42
+                ? Either<string, string>.FromRight("varmkorv")
+                : Either<string, string>.FromLeft($"id {id} not found");
+        }
+
+        private async Task<string> FormatGreeting(string name)
+        {
+            await Task.Yield();
+            return $"Hello, {name}!";
+        }
+
+        [Fact]
+        public async Task Await_then_map_and_fold()
+        {
+            var result = (await ParseId("42"))
+                .Map(id => id * 2)
+                .Fold(left => -1, right => right);
+
+            Assert.Equal(84, result);
+        }
+
+        [Fact]
+        public async Task Await_then_fold_on_left()
+        {
+            var result = (await ParseId("abc"))
+                .Fold(
+                    left => left,
+                    right => "ok");
+
+            Assert.Equal("'abc' is not a valid id", result);
+        }
+
+        [Fact]
+        public async Task Await_then_default_with()
+        {
+            var result = (await ParseId("abc"))
+                .DefaultWith(left => -1);
+
+            Assert.Equal(-1, result);
+        }
+
+        [Fact]
+        public async Task Async_bind_enables_fluent_chaining()
+        {
+            var result = await ParseId("42")
+                .BindAsync(LookupName);
+
+            Assert.Equal("varmkorv", result.RightValue());
+        }
+
+        [Fact]
+        public async Task Async_bind_short_circuits_on_left()
+        {
+            var result = await ParseId("abc")
+                .BindAsync(LookupName);
+
+            Assert.Equal("'abc' is not a valid id", result.LeftValue());
+        }
+
+        [Fact]
+        public async Task Async_bind_propagates_second_left()
+        {
+            var result = await ParseId("99")
+                .BindAsync(LookupName);
+
+            Assert.Equal("id 99 not found", result.LeftValue());
+        }
+
+        [Fact]
+        public async Task Async_map_transforms_right_value()
+        {
+            var result = await ParseId("42")
+                .BindAsync(LookupName)
+                .MapAsync(FormatGreeting);
+
+            Assert.Equal("Hello, varmkorv!", result.RightValue());
+        }
+
+        [Fact]
+        public async Task Async_chain_then_await_for_sync_operations()
+        {
+            var greeting = (await ParseId("42")
+                    .BindAsync(LookupName))
+                .Map(name => $"Welcome, {name}!")
+                .DefaultWith(left => $"Left: {left}");
+
+            Assert.Equal("Welcome, varmkorv!", greeting);
+        }
+
+        [Fact]
+        public async Task Sequence_enables_sync_map_with_async_function()
+        {
+            Either<string, string> name = Either<string, string>.FromRight("varmkorv");
+
+            var result = await name
+                .Map(FormatGreeting)
+                .Sequence();
+
+            Assert.Equal("Hello, varmkorv!", result.RightValue());
+        }
+
+        [Fact]
+        public async Task Sequence_skips_async_work_on_left()
+        {
+            Either<string, string> name = Either<string, string>.FromLeft("not found");
+
+            var result = await name
+                .Map(FormatGreeting)
+                .Sequence();
+
+            Assert.Equal("not found", result.LeftValue());
+        }
+
+        [Fact]
+        public async Task Sequence_propagates_faulted_inner_task()
+        {
+            var either = Either<string, Task<string>>.FromRight(
+                Task.FromException<string>(new InvalidOperationException("faulted")));
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => either.Sequence());
+
+            Assert.Equal("faulted", ex.Message);
+        }
+    }
+}

--- a/tests/EitherTests.cs
+++ b/tests/EitherTests.cs
@@ -1,0 +1,309 @@
+using Xunit;
+
+namespace Svan.Monads.UnitTests
+{
+    public class EitherTests
+    {
+        [Fact]
+        public void FromLeft_creates_a_left_either()
+        {
+            var either = Either<string, int>.FromLeft("error");
+            Assert.True(either.IsLeft);
+            Assert.False(either.IsRight);
+            Assert.Equal("error", either.LeftValue());
+        }
+
+        [Fact]
+        public void FromRight_creates_a_right_either()
+        {
+            var either = Either<string, int>.FromRight(42);
+            Assert.True(either.IsRight);
+            Assert.False(either.IsLeft);
+            Assert.Equal(42, either.RightValue());
+        }
+
+        [Fact]
+        public void Map_transforms_right_value()
+        {
+            var either = Either<string, int>.FromRight(5);
+            var result = either.Map(x => x * 2);
+            Assert.True(result.IsRight);
+            Assert.Equal(10, result.RightValue());
+        }
+
+        [Fact]
+        public void Map_short_circuits_on_left()
+        {
+            var either = Either<string, int>.FromLeft("error");
+            var result = either.Map(x => x * 2);
+            Assert.True(result.IsLeft);
+            Assert.Equal("error", result.LeftValue());
+        }
+
+        [Fact]
+        public void MapLeft_transforms_left_value()
+        {
+            var either = Either<string, int>.FromLeft("error");
+            var result = either.MapLeft(s => s.Length);
+            Assert.True(result.IsLeft);
+            Assert.Equal(5, result.LeftValue());
+        }
+
+        [Fact]
+        public void BindLeft_chains_left_values()
+        {
+            var either = Either<string, int>.FromLeft("error");
+            var result = either.BindLeft(l => Either<int, int>.FromLeft(l.Length));
+            Assert.True(result.IsLeft);
+            Assert.Equal(5, result.LeftValue());
+        }
+
+        [Fact]
+        public void BindLeft_short_circuits_on_right()
+        {
+            var either = Either<string, int>.FromRight(42);
+            var wasCalled = false;
+            var result = either.BindLeft(l => { wasCalled = true; return Either<int, int>.FromLeft(l.Length); });
+            Assert.False(wasCalled);
+            Assert.True(result.IsRight);
+            Assert.Equal(42, result.RightValue());
+        }
+
+        [Fact]
+        public void MapLeft_short_circuits_on_right()
+        {
+            var either = Either<string, int>.FromRight(42);
+            var result = either.MapLeft(s => s.Length);
+            Assert.True(result.IsRight);
+            Assert.Equal(42, result.RightValue());
+        }
+
+        [Fact]
+        public void Bind_chains_right_values()
+        {
+            var either = Either<string, int>.FromRight(5);
+            var result = either.Bind(x => Either<string, int>.FromRight(x + 3));
+            Assert.True(result.IsRight);
+            Assert.Equal(8, result.RightValue());
+        }
+
+        [Fact]
+        public void Bind_short_circuits_on_left()
+        {
+            var either = Either<string, int>.FromLeft("error");
+            var wasCalled = false;
+            var result = either.Bind(x => { wasCalled = true; return Either<string, int>.FromRight(x + 3); });
+            Assert.False(wasCalled);
+            Assert.True(result.IsLeft);
+            Assert.Equal("error", result.LeftValue());
+        }
+
+        [Fact]
+        public void Do_fires_only_on_right()
+        {
+            var called = false;
+            Either<string, int>.FromRight(5)
+                .Do(x => { called = true; Assert.Equal(5, x); });
+            Assert.True(called);
+
+            Either<string, int>.FromLeft("error")
+                .Do(_ => Assert.Fail("Should not be called on left"));
+        }
+
+        [Fact]
+        public void DoIfLeft_fires_only_on_left()
+        {
+            var called = false;
+            Either<string, int>.FromLeft("error")
+                .DoIfLeft(x => { called = true; Assert.Equal("error", x); });
+            Assert.True(called);
+
+            Either<string, int>.FromRight(5)
+                .DoIfLeft(_ => Assert.Fail("Should not be called on right"));
+        }
+
+        [Fact]
+        public void Fold_calls_correct_branch()
+        {
+            var rightResult = Either<string, int>.FromRight(5)
+                .Fold(l => -1, r => r * 2);
+            Assert.Equal(10, rightResult);
+
+            var leftResult = Either<string, int>.FromLeft("error")
+                .Fold(l => l.Length, r => r * 2);
+            Assert.Equal(5, leftResult);
+        }
+
+        [Fact]
+        public void DefaultWith_func_returns_right_value_or_fallback_from_left()
+        {
+            Assert.Equal(42, Either<string, int>.FromRight(42).DefaultWith(l => l.Length));
+            Assert.Equal(5, Either<string, int>.FromLeft("error").DefaultWith(l => l.Length));
+        }
+
+        [Fact]
+        public void DefaultWith_value_returns_right_value_or_fallback()
+        {
+            Assert.Equal(42, Either<string, int>.FromRight(42).DefaultWith(0));
+            Assert.Equal(0, Either<string, int>.FromLeft("error").DefaultWith(0));
+        }
+
+        [Fact]
+        public void OrThrow_on_left_throws_invalid_operation_exception()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                Either<string, int>.FromLeft("error").OrThrow());
+        }
+
+        [Fact]
+        public void OrThrow_on_right_returns_value()
+        {
+            Assert.Equal(42, Either<string, int>.FromRight(42).OrThrow());
+        }
+
+        [Fact]
+        public void Swap_flips_sides()
+        {
+            var swappedRight = Either<string, int>.FromRight(42).Swap();
+            Assert.True(swappedRight.IsLeft);
+            Assert.Equal(42, swappedRight.LeftValue());
+
+            var swappedLeft = Either<string, int>.FromLeft("error").Swap();
+            Assert.True(swappedLeft.IsRight);
+            Assert.Equal("error", swappedLeft.RightValue());
+        }
+
+        [Fact]
+        public void Zip_combines_two_rights()
+        {
+            var result = Either<string, int>.FromRight(5)
+                .Zip(Either<string, int>.FromRight(3), (a, b) => a + b);
+            Assert.True(result.IsRight);
+            Assert.Equal(8, result.RightValue());
+        }
+
+        [Fact]
+        public void Zip_returns_first_left_encountered()
+        {
+            var result = Either<string, int>.FromRight(5)
+                .Zip(Either<string, int>.FromLeft("first error"), (a, b) => a + b);
+            Assert.True(result.IsLeft);
+            Assert.Equal("first error", result.LeftValue());
+
+            var result2 = Either<string, int>.FromLeft("first error")
+                .Zip(Either<string, int>.FromLeft("second error"), (a, b) => a + b);
+            Assert.True(result2.IsLeft);
+            Assert.Equal("first error", result2.LeftValue());
+        }
+
+        [Fact]
+        public void Zip_five_combines_all_rights()
+        {
+            var result = Either<string, int>.FromRight(1)
+                .Zip(
+                    Either<string, int>.FromRight(2),
+                    Either<string, int>.FromRight(3),
+                    Either<string, int>.FromRight(4),
+                    Either<string, int>.FromRight(5),
+                    (a, b, c, d, e) => a + b + c + d + e);
+            Assert.True(result.IsRight);
+            Assert.Equal(15, result.RightValue());
+        }
+
+        [Fact]
+        public void Sequence_returns_right_with_all_values_when_all_right()
+        {
+            var eithers = new[]
+            {
+                Either<string, int>.FromRight(1),
+                Either<string, int>.FromRight(2),
+                Either<string, int>.FromRight(3),
+            };
+
+            var result = eithers.Sequence();
+            Assert.True(result.IsRight);
+            Assert.Equal(new[] { 1, 2, 3 }, result.RightValue());
+        }
+
+        [Fact]
+        public void Sequence_returns_first_left_when_any_is_left()
+        {
+            var eithers = new[]
+            {
+                Either<string, int>.FromRight(1),
+                Either<string, int>.FromLeft("first error"),
+                Either<string, int>.FromLeft("second error"),
+            };
+
+            var result = eithers.Sequence();
+            Assert.True(result.IsLeft);
+            Assert.Equal("first error", result.LeftValue());
+        }
+
+        [Fact]
+        public void Flatten_returns_inner_right_when_outer_is_right()
+        {
+            var nested = Either<string, Either<string, int>>.FromRight(Either<string, int>.FromRight(42));
+            var flat = nested.Flatten();
+            Assert.True(flat.IsRight);
+            Assert.Equal(42, flat.RightValue());
+        }
+
+        [Fact]
+        public void Flatten_propagates_outer_left()
+        {
+            var nested = Either<string, Either<string, int>>.FromLeft("outer error");
+            var flat = nested.Flatten();
+            Assert.True(flat.IsLeft);
+            Assert.Equal("outer error", flat.LeftValue());
+        }
+
+        [Fact]
+        public void Flatten_propagates_inner_left_when_outer_is_right()
+        {
+            var nested = Either<string, Either<string, int>>.FromRight(Either<string, int>.FromLeft("inner error"));
+            var flat = nested.Flatten();
+            Assert.True(flat.IsLeft);
+            Assert.Equal("inner error", flat.LeftValue());
+        }
+
+        [Fact]
+        public void ToOption_converts_right_to_some()
+        {
+            Either<string, int>.FromRight(42).ToOption().AssertSome(42);
+        }
+
+        [Fact]
+        public void ToOption_converts_left_to_none()
+        {
+            Either<string, int>.FromLeft("error").ToOption().AssertNone();
+        }
+
+        [Fact]
+        public void ToResult_converts_right_to_success()
+        {
+            Either<string, int>.FromRight(42).ToResult().AssertSuccess(42);
+        }
+
+        [Fact]
+        public void ToResult_converts_left_to_error()
+        {
+            Either<string, int>.FromLeft("error").ToResult().AssertError("error");
+        }
+
+        [Fact]
+        public void Merge_can_combine_eithers()
+        {
+            var result = Either<string, int>.FromRight(10)
+                .Merge(Either<string, int>.FromRight(20))
+                .Merge(Either<string, int>.FromRight(30))
+                .Merge(Either<string, int>.FromRight(40))
+                .Merge(Either<string, int>.FromRight(50))
+                .Fold(
+                    _ => 0,
+                    group => group.Item1 + group.Item2 + group.Item3 + group.Item4 + group.Item5);
+
+            Assert.Equal(150, result);
+        }
+    }
+}


### PR DESCRIPTION
A general-purpose discriminated union where both sides carry meaning. Right-biased for chainable pipelines, without the opinionated error/success semantics of `Result<TError, TSuccess>`.