### PR TITLE
Upgrade to .NET 10 and enrich XML documentation with examples

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "9.x"
+          dotnet-version: "10.x"
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/examples/esoteric-examples/esoteric-examples.csproj
+++ b/examples/esoteric-examples/esoteric-examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>result_examples</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/examples/option-examples/option-examples.csproj
+++ b/examples/option-examples/option-examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>option_examples</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/examples/result-examples/result-examples.csproj
+++ b/examples/result-examples/result-examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>result_examples</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-dotnet = "9"
+dotnet = "10"

--- a/src/Either/AsyncEitherExtensions.cs
+++ b/src/Either/AsyncEitherExtensions.cs
@@ -3,10 +3,11 @@ using System.Threading.Tasks;
 
 namespace Svan.Monads
 {
+    /// <summary>Async extension methods for <see cref="Either{TLeft,TRight}"/> enabling fluent async pipelines.</summary>
     public static class AsyncEitherExtensions
     {
         /// <summary>
-        /// Flips an <c>Either&lt;TLeft, Task&lt;TRight&gt;&gt;</c> into a <c>Task&lt;Either&lt;TLeft, TRight&gt;&gt;</c>.
+        /// Flips an <see cref="Either{TLeft, TRight}"/> of <see cref="Task{TResult}"/> into a <see cref="Task{TResult}"/> of <see cref="Either{TLeft, TRight}"/>.
         /// Awaits the inner task when <c>Right</c>, returns the left value immediately when <c>Left</c>.
         /// </summary>
         public static async Task<Either<TLeft, TRight>> Sequence<TLeft, TRight>(
@@ -22,9 +23,17 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Binds an async function over a <c>Task&lt;Either&lt;TLeft, TRight&gt;&gt;</c>.
+        /// Binds an async function over a <see cref="Task{TResult}"/> of <see cref="Either{TLeft, TRight}"/>.
         /// The binder is only called when the either is <c>Right</c>; otherwise short-circuits with the existing left value.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// async Task&lt;Either&lt;string, string&gt;&gt; LookupName(int id) { ... }
+        ///
+        /// var name = await ParseId("42")
+        ///     .BindAsync(id => LookupName(id));
+        /// </code>
+        /// </example>
         public static async Task<Either<TLeft, TOut>> BindAsync<TLeft, TRight, TOut>(
             this Task<Either<TLeft, TRight>> eitherTask,
             Func<TRight, Task<Either<TLeft, TOut>>> binder)
@@ -36,9 +45,18 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Maps an async function over a <c>Task&lt;Either&lt;TLeft, TRight&gt;&gt;</c>.
+        /// Maps an async function over a <see cref="Task{TResult}"/> of <see cref="Either{TLeft, TRight}"/>.
         /// The mapper is only called when the either is <c>Right</c>; otherwise short-circuits with the existing left value.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// async Task&lt;string&gt; FormatGreeting(string name) { ... }
+        ///
+        /// var greeting = await ParseId("42")
+        ///     .BindAsync(id => LookupName(id))
+        ///     .MapAsync(name => FormatGreeting(name));
+        /// </code>
+        /// </example>
         public static async Task<Either<TLeft, TOut>> MapAsync<TLeft, TRight, TOut>(
             this Task<Either<TLeft, TRight>> eitherTask,
             Func<TRight, Task<TOut>> mapper)

--- a/src/Either/Either.cs
+++ b/src/Either/Either.cs
@@ -162,7 +162,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Fold into a value of type <c>TOut</c> with supplied functions for each case.
+        /// Fold into a value of type <typeparamref name="TOut"/> with supplied functions for each case.
         /// </summary>
         /// <example>
         /// <code>

--- a/src/Either/Either.cs
+++ b/src/Either/Either.cs
@@ -6,12 +6,25 @@ namespace Svan.Monads
     /// A general-purpose discriminated union where both sides carry meaning.
     /// Right-biased for chainable pipelines, without the opinionated error/success semantics of <see cref="Result{TError, TSuccess}"/>.
     /// </summary>
+    /// <example>
+    /// <code>
+    /// var result = Either&lt;string, int&gt;.FromRight(42)
+    ///     .Map(n => n * 2)
+    ///     .Bind(n => n > 50
+    ///         ? Either&lt;string, int&gt;.FromRight(n)
+    ///         : Either&lt;string, int&gt;.FromLeft("too small"))
+    ///     .DefaultWith(_ => 0);
+    /// // result == 84
+    /// </code>
+    /// </example>
     public class Either<TLeft, TRight> : Union<TLeft, TRight>
     {
         internal Either(Left<TLeft> value) : base(value) { }
         internal Either(Right<TRight> value) : base(value) { }
 
+        /// <summary>Creates a Left either wrapping <paramref name="value"/>.</summary>
         public static Either<TLeft, TRight> FromLeft(TLeft value) => new(new Left<TLeft>(value));
+        /// <summary>Creates a Right either wrapping <paramref name="value"/>.</summary>
         public static Either<TLeft, TRight> FromRight(TRight value) => new(new Right<TRight>(value));
 
         /// <summary>
@@ -27,18 +40,41 @@ namespace Svan.Monads
         /// <summary>
         /// Map the right value to a new type. Short-circuits on Left.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var doubled = Either&lt;string, int&gt;.FromRight(21).Map(x => x * 2); // Right(42)
+        /// var left    = Either&lt;string, int&gt;.FromLeft("err").Map(x => x * 2); // Left("err")
+        /// </code>
+        /// </example>
         public Either<TLeft, TOut> Map<TOut>(Func<TRight, TOut> map)
             => Match(Either<TLeft, TOut>.FromLeft, r => Either<TLeft, TOut>.FromRight(map(r)));
 
         /// <summary>
-        /// Bind the right value to a new <c>Either&lt;TLeft, TOut&gt;</c>. Short-circuits on Left.
+        /// Bind the right value to a new <see cref="Either{TLeft, TRight}"/>. Short-circuits on Left.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var result  = Either&lt;string, int&gt;.FromRight(10)
+        ///     .Bind(n => n > 0
+        ///         ? Either&lt;string, int&gt;.FromRight(n)
+        ///         : Either&lt;string, int&gt;.FromLeft("non-positive")); // Right(10)
+        ///
+        /// var skipped = Either&lt;string, int&gt;.FromLeft("err")
+        ///     .Bind(n => Either&lt;string, int&gt;.FromRight(n * 2)); // Left("err") — binder not called
+        /// </code>
+        /// </example>
         public Either<TLeft, TOut> Bind<TOut>(Func<TRight, Either<TLeft, TOut>> binder)
             => Match(Either<TLeft, TOut>.FromLeft, binder);
 
         /// <summary>
         /// Execute an action on the right value. Returns the current Either unchanged.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// Either&lt;string, int&gt;.FromRight(42).Do(n => Console.WriteLine(n));    // prints 42
+        /// Either&lt;string, int&gt;.FromLeft("err").Do(n => Console.WriteLine(n)); // nothing printed
+        /// </code>
+        /// </example>
         public Either<TLeft, TRight> Do(Action<TRight> @do)
         {
             if (IsRight)
@@ -52,6 +88,12 @@ namespace Svan.Monads
         /// <summary>
         /// Get the right value or a fallback derived from the left value.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var value    = Either&lt;string, int&gt;.FromRight(42).DefaultWith(l => l.Length); // 42
+        /// var fallback = Either&lt;string, int&gt;.FromLeft("err").DefaultWith(l => l.Length); // 3
+        /// </code>
+        /// </example>
         public TRight DefaultWith(Func<TLeft, TRight> fallback) => Match(fallback, r => r);
 
         /// <summary>
@@ -62,6 +104,12 @@ namespace Svan.Monads
         /// <summary>
         /// Get the right value or throw an <see cref="InvalidOperationException"/>.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var value = Either&lt;string, int&gt;.FromRight(42).OrThrow(); // 42
+        /// Either&lt;string, int&gt;.FromLeft("err").OrThrow();           // throws InvalidOperationException
+        /// </code>
+        /// </example>
         public TRight OrThrow()
             => Match(
                 l => throw new InvalidOperationException($"Expected a right value of {typeof(TRight).Name} but was left: {l}."),
@@ -70,18 +118,39 @@ namespace Svan.Monads
         /// <summary>
         /// Map the left value to a new type. Short-circuits on Right.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var upper = Either&lt;string, int&gt;.FromLeft("err").MapLeft(s => s.ToUpper()); // Left("ERR")
+        /// var right = Either&lt;string, int&gt;.FromRight(42).MapLeft(s => s.ToUpper());   // Right(42)
+        /// </code>
+        /// </example>
         public Either<TOut, TRight> MapLeft<TOut>(Func<TLeft, TOut> map)
             => Match(l => Either<TOut, TRight>.FromLeft(map(l)), Either<TOut, TRight>.FromRight);
 
         /// <summary>
-        /// Bind the left value to a new <c>Either&lt;TOut, TRight&gt;</c>. Short-circuits on Right.
+        /// Bind the left value to a new <see cref="Either{TLeft, TRight}"/>. Short-circuits on Right.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var result    = Either&lt;string, int&gt;.FromLeft("err")
+        ///     .BindLeft(l => Either&lt;int, int&gt;.FromLeft(l.Length)); // Left(3)
+        ///
+        /// var passThrough = Either&lt;string, int&gt;.FromRight(42)
+        ///     .BindLeft(l => Either&lt;int, int&gt;.FromLeft(l.Length)); // Right(42) — binder not called
+        /// </code>
+        /// </example>
         public Either<TOut, TRight> BindLeft<TOut>(Func<TLeft, Either<TOut, TRight>> binder)
             => Match(binder, Either<TOut, TRight>.FromRight);
 
         /// <summary>
         /// Execute an action on the left value. Returns the current Either unchanged.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// Either&lt;string, int&gt;.FromLeft("err").DoIfLeft(l => Console.WriteLine(l)); // prints "err"
+        /// Either&lt;string, int&gt;.FromRight(42).DoIfLeft(l => Console.WriteLine(l));   // nothing printed
+        /// </code>
+        /// </example>
         public Either<TLeft, TRight> DoIfLeft(Action<TLeft> @do)
         {
             if (IsLeft)
@@ -95,12 +164,24 @@ namespace Svan.Monads
         /// <summary>
         /// Fold into a value of type <c>TOut</c> with supplied functions for each case.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var msg  = Either&lt;string, int&gt;.FromRight(42).Fold(l => $"left: {l}", r => $"right: {r}"); // "right: 42"
+        /// var left = Either&lt;string, int&gt;.FromLeft("err").Fold(l => $"left: {l}", r => $"right: {r}"); // "left: err"
+        /// </code>
+        /// </example>
         public TOut Fold<TOut>(Func<TLeft, TOut> caseLeft, Func<TRight, TOut> caseRight)
             => Match(caseLeft, caseRight);
 
         /// <summary>
         /// Swap left and right sides.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var swapped = Either&lt;string, int&gt;.FromRight(42).Swap(); // Left(42) as Either&lt;int, string&gt;
+        /// var flipped = Either&lt;string, int&gt;.FromLeft("err").Swap(); // Right("err") as Either&lt;int, string&gt;
+        /// </code>
+        /// </example>
         public Either<TRight, TLeft> Swap()
             => Match(Either<TRight, TLeft>.FromRight, Either<TRight, TLeft>.FromLeft);
 
@@ -167,11 +248,23 @@ namespace Svan.Monads
         /// <summary>
         /// Convert to <see cref="Option{TRight}"/>. Left becomes None, Right becomes Some.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var some = Either&lt;string, int&gt;.FromRight(42).ToOption(); // Some(42)
+        /// var none = Either&lt;string, int&gt;.FromLeft("err").ToOption(); // None
+        /// </code>
+        /// </example>
         public Option<TRight> ToOption() => Match(_ => Option<TRight>.None(), Option<TRight>.Some);
 
         /// <summary>
         /// Convert to <see cref="Result{TLeft, TRight}"/>. Left becomes Error, Right becomes Success.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var success = Either&lt;string, int&gt;.FromRight(42).ToResult(); // Success(42)
+        /// var error   = Either&lt;string, int&gt;.FromLeft("err").ToResult(); // Error("err")
+        /// </code>
+        /// </example>
         public Result<TLeft, TRight> ToResult() => Match(Result<TLeft, TRight>.Error, Result<TLeft, TRight>.Success);
     }
 }

--- a/src/Either/EitherConstructors.cs
+++ b/src/Either/EitherConstructors.cs
@@ -1,5 +1,6 @@
 namespace Svan.Monads;
 
+/// <summary>Non-generic factory methods for creating <see cref="Either{TLeft,TRight}"/> instances.</summary>
 public static class Either
 {
     /// <summary>
@@ -14,10 +15,20 @@ public static class Either
     /// <summary>
     /// Creates an <c>Either</c> (left) with the provided value.
     /// </summary>
+    /// <example>
+    /// <code>
+    /// Either&lt;string, int&gt; left = "error".ToLeft&lt;string, int&gt;();
+    /// </code>
+    /// </example>
     public static Either<TLeft, TRight> ToLeft<TLeft, TRight>(this TLeft value) => FromLeft<TLeft, TRight>(value);
     /// <summary>
     /// Creates an <c>Either</c> (right) with the provided value.
     /// </summary>
+    /// <example>
+    /// <code>
+    /// Either&lt;string, int&gt; right = 42.ToRight&lt;string, int&gt;();
+    /// </code>
+    /// </example>
     public static Either<TLeft, TRight> ToRight<TLeft, TRight>(this TRight value) => FromRight<TLeft, TRight>(value);
 }
 

--- a/src/Either/EitherExtensions.cs
+++ b/src/Either/EitherExtensions.cs
@@ -3,11 +3,23 @@ using System.Collections.Generic;
 
 namespace Svan.Monads
 {
+    /// <summary>Extension methods for combining and transforming <see cref="Either{TLeft,TRight}"/> values.</summary>
     public static class EitherExtensions
     {
         /// <summary>
         /// Merge two eithers together. Only merges if both are Right.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var merged = Either&lt;string, int&gt;.FromRight(1).Merge(Either&lt;string, string&gt;.FromRight("a"));
+        /// // Right(Tuple(1, "a"))
+        ///
+        /// // Chain further Merge calls to collect up to five values:
+        /// var triple = Either&lt;string, int&gt;.FromRight(1)
+        ///     .Merge(Either&lt;string, int&gt;.FromRight(2))
+        ///     .Merge(Either&lt;string, int&gt;.FromRight(3));
+        /// </code>
+        /// </example>
         public static Either<TLeft, Tuple<TFirst, TSecond>> Merge<TLeft, TFirst, TSecond>(
             this Either<TLeft, TFirst> first, Either<TLeft, TSecond> second) =>
                 first.Zip(second, (f, s) => new Tuple<TFirst, TSecond>(f, s));
@@ -37,6 +49,15 @@ namespace Svan.Monads
         /// Combine a sequence of eithers. Returns Right with all values if every either is Right,
         /// or the first Left encountered.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var all  = new[] { Either&lt;string, int&gt;.FromRight(1), Either&lt;string, int&gt;.FromRight(2) }.Sequence();
+        /// // Right([1, 2])
+        ///
+        /// var fail = new[] { Either&lt;string, int&gt;.FromRight(1), Either&lt;string, int&gt;.FromLeft("oops") }.Sequence();
+        /// // Left("oops")
+        /// </code>
+        /// </example>
         public static Either<TLeft, IEnumerable<TRight>> Sequence<TLeft, TRight>(
             this IEnumerable<Either<TLeft, TRight>> eithers)
         {
@@ -56,9 +77,21 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Flattens a nested <c>Either&lt;TLeft, Either&lt;TLeft, TRight&gt;&gt;</c> into an <c>Either&lt;TLeft, TRight&gt;</c>.
+        /// Flattens a nested <see cref="Either{TLeft, TRight}"/> where the right is itself an <see cref="Either{TLeft, TRight}"/> into a flat <see cref="Either{TLeft, TRight}"/>.
         /// Returns the inner either when Right, or propagates the outer Left.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var flat     = Either&lt;string, Either&lt;string, int&gt;&gt;.FromRight(Either&lt;string, int&gt;.FromRight(42)).Flatten();
+        /// // Right(42)
+        ///
+        /// var innerLeft = Either&lt;string, Either&lt;string, int&gt;&gt;.FromRight(Either&lt;string, int&gt;.FromLeft("inner")).Flatten();
+        /// // Left("inner")
+        ///
+        /// var outerLeft = Either&lt;string, Either&lt;string, int&gt;&gt;.FromLeft("outer").Flatten();
+        /// // Left("outer")
+        /// </code>
+        /// </example>
         public static Either<TLeft, TRight> Flatten<TLeft, TRight>(
             this Either<TLeft, Either<TLeft, TRight>> either)
             => either.DefaultWith(Either<TLeft, TRight>.FromLeft);

--- a/src/Option/AsyncOptionExtensions.cs
+++ b/src/Option/AsyncOptionExtensions.cs
@@ -3,10 +3,11 @@ using System.Threading.Tasks;
 
 namespace Svan.Monads
 {
+    /// <summary>Async extension methods for <see cref="Option{T}"/> enabling fluent async pipelines.</summary>
     public static class AsyncOptionExtensions
     {
         /// <summary>
-        /// Flips an <c>Option&lt;Task&lt;T&gt;&gt;</c> into a <c>Task&lt;Option&lt;T&gt;&gt;</c>.
+        /// Flips an <see cref="Option{T}"/> of <see cref="Task{TResult}"/> into a <see cref="Task{TResult}"/> of <see cref="Option{T}"/>.
         /// Awaits the inner task when <c>Some</c>, returns <c>None</c> immediately when <c>None</c>.
         /// </summary>
         public static async Task<Option<T>> Sequence<T>(this Option<Task<T>> optionTask)
@@ -22,9 +23,17 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Binds an async function over a <c>Task&lt;Option&lt;T&gt;&gt;</c>.
+        /// Binds an async function over a <see cref="Task{TResult}"/> of <see cref="Option{T}"/>.
         /// The binder is only called when the option is <c>Some</c>; otherwise short-circuits to <c>None</c>.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// async Task&lt;Option&lt;string&gt;&gt; FindEmail(int userId) { ... }
+        ///
+        /// var email = await FindUserId("malin")
+        ///     .BindAsync(id => FindEmail(id));
+        /// </code>
+        /// </example>
         public static async Task<Option<TOut>> BindAsync<T, TOut>(
             this Task<Option<T>> optionTask,
             Func<T, Task<Option<TOut>>> binder)
@@ -34,9 +43,18 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Maps an async function over a <c>Task&lt;Option&lt;T&gt;&gt;</c>.
+        /// Maps an async function over a <see cref="Task{TResult}"/> of <see cref="Option{T}"/>.
         /// The mapper is only called when the option is <c>Some</c>; otherwise short-circuits to <c>None</c>.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// async Task&lt;string&gt; NormalizeEmail(string email) { ... }
+        ///
+        /// var normalized = await FindUserId("malin")
+        ///     .BindAsync(id => FindEmail(id))
+        ///     .MapAsync(email => NormalizeEmail(email));
+        /// </code>
+        /// </example>
         public static async Task<Option<TOut>> MapAsync<T, TOut>(
             this Task<Option<T>> optionTask,
             Func<T, Task<TOut>> mapper)

--- a/src/Option/Option.cs
+++ b/src/Option/Option.cs
@@ -61,7 +61,7 @@ namespace Svan.Monads
         /// <summary>
         /// Map the value of the option to an <see cref="Option{T}"/> using a mapping function. The mapping function will not be executed if the current state of the option is <c>None</c>.
         /// </summary>
-        /// <param name="mapping">A function that returns a value of <c>TOut</c></param>
+        /// <param name="mapping">A function that returns a value of <typeparamref name="TOut"/></param>
         /// <typeparam name="TOut"></typeparam>
         /// <returns>An option of the output type of the mapping</returns>
         /// <example>
@@ -128,7 +128,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Fold into value of type <c>TOut</c> with supplied functions for case <c>None</c> and case <c>Some</c>.
+        /// Fold into value of type <typeparamref name="TOut"/> with supplied functions for case <c>None</c> and case <c>Some</c>.
         /// </summary>
         /// <example>
         /// <code>

--- a/src/Option/Option.cs
+++ b/src/Option/Option.cs
@@ -5,12 +5,22 @@ namespace Svan.Monads
     /// <summary>
     /// Union of <c>None</c> and <c>T</c> with monad features for the Maybe flow control
     /// </summary>
+    /// <example>
+    /// <code>
+    /// var port = GetConfigValue("PORT")
+    ///     .Bind(s => int.TryParse(s, out var n) ? Option.Some(n) : Option&lt;int&gt;.None())
+    ///     .Filter(n => n is > 0 and &lt; 65536)
+    ///     .DefaultWith(8080);
+    /// </code>
+    /// </example>
     public class Option<T> : Union<None, T>
     {
         internal Option(None value) : base(new Left<None>(value)) { }
         internal Option(T value) : base(new Right<T>(value)) { }
 
+        /// <summary>Creates a <c>None</c> option.</summary>
         public static Option<T> None() => new(new None());
+        /// <summary>Creates a <c>Some</c> option wrapping <paramref name="value"/>.</summary>
         public static Option<T> Some(T value) => new(value);
 
         /// <summary>
@@ -29,21 +39,37 @@ namespace Svan.Monads
         public T Value() => IsSome() ? AsRight : throw new NullReferenceException($"Expected some {typeof(T).Name} but was none.");
 
         /// <summary>
-        /// Bind the <c>Option&lt;T&gt;</c> to an <c>Option&lt;TOut&gt;</c> using a binder function. The binder function will not be executed if the current state of the option is <c>None</c>.
+        /// Bind the <see cref="Option{T}"/> to an <see cref="Option{T}"/> using a binder function. The binder function will not be executed if the current state of the option is <c>None</c>.
         /// </summary>
-        /// <param name="binder">A function that returns an <c>Option&lt;TOut&gt;</c></param>
+        /// <param name="binder">A function that returns an <see cref="Option{T}"/></param>
         /// <returns>An option of the output type of the binder. </returns>
+        /// <example>
+        /// <code>
+        /// Option&lt;int&gt; ParsePositive(string s) =>
+        ///     int.TryParse(s, out var n) &amp;&amp; n > 0 ? Option.Some(n) : Option&lt;int&gt;.None();
+        ///
+        /// var some    = Option.Some("42").Bind(ParsePositive); // Some(42)
+        /// var none    = Option.Some("-1").Bind(ParsePositive); // None
+        /// var skipped = Option&lt;string&gt;.None().Bind(ParsePositive); // None — binder not called
+        /// </code>
+        /// </example>
         public Option<TOut> Bind<TOut>(Func<T, Option<TOut>> binder)
             => Match(
                 _ => Option<TOut>.None(),
                 binder);
 
         /// <summary>
-        /// Map the value of the option to an <c>Option&lt;TOut&gt;</c> using a mapping function. The mapping function will not be executed if the current state of the option is <c>None</c>.
+        /// Map the value of the option to an <see cref="Option{T}"/> using a mapping function. The mapping function will not be executed if the current state of the option is <c>None</c>.
         /// </summary>
         /// <param name="mapping">A function that returns a value of <c>TOut</c></param>
         /// <typeparam name="TOut"></typeparam>
         /// <returns>An option of the output type of the mapping</returns>
+        /// <example>
+        /// <code>
+        /// var doubled = Option.Some(21).Map(x => x * 2);       // Some(42)
+        /// var none    = Option&lt;int&gt;.None().Map(x => x * 2); // None — mapper not called
+        /// </code>
+        /// </example>
         public Option<TOut> Map<TOut>(Func<T, TOut> mapping)
             => Match(
                 _ => Option<TOut>.None(),
@@ -54,16 +80,28 @@ namespace Svan.Monads
         /// </summary>
         /// <param name="filter"></param>
         /// <returns><c>Some</c> when filter returns true. <c>None</c> when filter returns false or current state of option is <c>None</c></returns>
+        /// <example>
+        /// <code>
+        /// var even = Option.Some(4).Filter(n => n % 2 == 0); // Some(4)
+        /// var odd  = Option.Some(3).Filter(n => n % 2 == 0); // None
+        /// </code>
+        /// </example>
         public Option<T> Filter(Func<T, bool> filter)
             => Match(
                 _ => None(),
                 value => filter(value) ? Some(value) : None());
 
         /// <summary>
-        /// Do lets you fire and forget an action that is executed only when the value is <c>Some&lt;T&gt;</c>
+        /// Do lets you fire and forget an action that is executed only when the value is <c>Some</c>
         /// </summary>
         /// <param name="do">An action that takes a single parameter of T</param>
         /// <returns>The current state of the Option</returns>
+        /// <example>
+        /// <code>
+        /// Option.Some(42).Do(n => Console.WriteLine(n));       // prints 42
+        /// Option&lt;int&gt;.None().Do(n => Console.WriteLine(n)); // nothing printed
+        /// </code>
+        /// </example>
         public Option<T> Do(Action<T> @do)
         {
             if (IsSome())
@@ -92,6 +130,12 @@ namespace Svan.Monads
         /// <summary>
         /// Fold into value of type <c>TOut</c> with supplied functions for case <c>None</c> and case <c>Some</c>.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var msg = Option.Some(42).Fold(() => "nothing", n => $"got {n}"); // "got 42"
+        /// var def = Option&lt;int&gt;.None().Fold(() => "nothing", n => $"got {n}"); // "nothing"
+        /// </code>
+        /// </example>
         public TOut Fold<TOut>(Func<TOut> caseNone, Func<T, TOut> caseSome)
             => Match(
                 _ => caseNone(),
@@ -100,6 +144,12 @@ namespace Svan.Monads
         /// <summary>
         /// Get the value of <c>Some</c> or a default value from the supplied function.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var value    = Option.Some(42).DefaultWith(() => 0);    // 42
+        /// var fallback = Option&lt;int&gt;.None().DefaultWith(() => 0); // 0
+        /// </code>
+        /// </example>
         public T DefaultWith(Func<T> defaultNone)
             => Fold(
                 defaultNone,
@@ -116,6 +166,12 @@ namespace Svan.Monads
         /// <summary>
         /// Get the value of <c>Some</c> or throw a <see cref="NullReferenceException"/>.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var value = Option.Some(42).OrThrow(); // 42
+        /// Option&lt;int&gt;.None().OrThrow();         // throws NullReferenceException
+        /// </code>
+        /// </example>
         public T OrThrow()
             => Fold(
                 () => throw new NullReferenceException($"Expected some {typeof(T).Name} but was none."),
@@ -202,9 +258,14 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Create a <c>Result&lt;TError, T&gt;</c> from an <c>Option&lt;T&gt;</c> by supplying a mapper for the error case
+        /// Create a <see cref="Result{TError, TSuccess}"/> from an <see cref="Option{T}"/> by supplying a mapper for the error case
         /// </summary>
-
+        /// <example>
+        /// <code>
+        /// var success = Option.Some(42).ToResult(() => "was none");      // Success(42)
+        /// var error   = Option&lt;int&gt;.None().ToResult(() => "was none"); // Error("was none")
+        /// </code>
+        /// </example>
         public Result<TError, T> ToResult<TError>(Func<TError> defaultError)
          => Fold(
                 () => Result<TError, T>.Error(defaultError()),

--- a/src/Option/OptionConstructors.cs
+++ b/src/Option/OptionConstructors.cs
@@ -1,5 +1,6 @@
 namespace Svan.Monads;
 
+/// <summary>Non-generic factory methods for creating <see cref="Option{T}"/> instances.</summary>
 public static class Option
 {
     /// <summary>
@@ -13,10 +14,18 @@ public static class Option
     public static Option<T> None<T>() => new(new None());
 
     /// <summary>
-    /// Converts any type <c>T</c> to <c>Option&lt;T&gt;</c>. 
+    /// Converts any type <c>T</c> to <see cref="Option{T}"/>.
     /// </summary>
-    /// <returns>Returns <c>Some&lt;T&gt;</c> for value types.
-    /// Returns <c>Some&lt;T&gt;</c> for reference types that are not <c>null</c> and <c>None</c> for reference types that are <c>null</c>.</returns>
+    /// <returns>Returns <c>Some</c> for value types.
+    /// Returns <c>Some</c> for reference types that are not <c>null</c> and <c>None</c> for reference types that are <c>null</c>.</returns>
+    /// <example>
+    /// <code>
+    /// var some = "hello".ToOption();   // Some("hello")
+    /// string? s = null;
+    /// var none = s.ToOption();         // None
+    /// var intSome = 42.ToOption();     // Some(42) — value types are always Some
+    /// </code>
+    /// </example>
     public static Option<T> ToOption<T>(this T value)
     {
         Option<T> result;

--- a/src/Option/OptionExtensions.cs
+++ b/src/Option/OptionExtensions.cs
@@ -3,12 +3,22 @@ using System.Collections.Generic;
 
 namespace Svan.Monads
 {
+    /// <summary>Extension methods for combining and transforming <see cref="Option{T}"/> values.</summary>
     public static class OptionExtensions
     {
         /// <summary>
         /// Merge two or more options together. Merge will only be performed if all involved options resolve to Some.
         /// </summary>
         /// <returns>The values merged into an option of a tuple</returns>
+        /// <example>
+        /// <code>
+        /// var merged = Option.Some(1).Merge(Option.Some("a")); // Some(Tuple(1, "a"))
+        /// var none   = Option.Some(1).Merge(Option&lt;string&gt;.None()); // None
+        ///
+        /// // Chain further Merge calls to collect up to five values:
+        /// var triple = Option.Some(1).Merge(Option.Some(2)).Merge(Option.Some(3));
+        /// </code>
+        /// </example>
         public static Option<Tuple<TFirst, TSecond>> Merge<TFirst, TSecond>(
             this Option<TFirst> first, Option<TSecond> second) =>
             first.Zip(second, (f, s) => new Tuple<TFirst, TSecond>(f, s));
@@ -43,6 +53,12 @@ namespace Svan.Monads
         /// Combine a sequence of options together. Combine will only be performed if all involved options resolve to Some.
         /// </summary>
         /// <returns>The values merged into an option of an Enumerable</returns>
+        /// <example>
+        /// <code>
+        /// var some = new[] { Option.Some(1), Option.Some(2), Option.Some(3) }.Sequence(); // Some([1, 2, 3])
+        /// var none = new[] { Option.Some(1), Option&lt;int&gt;.None() }.Sequence();            // None
+        /// </code>
+        /// </example>
         public static Option<IEnumerable<T>> Sequence<T>(this IEnumerable<Option<T>> options)
         {
             var result = new List<T>();
@@ -61,9 +77,16 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Flattens a nested <c>Option&lt;Option&lt;T&gt;&gt;</c> into an <c>Option&lt;T&gt;</c>.
+        /// Flattens a nested <see cref="Option{T}"/> where the value is itself an <see cref="Option{T}"/> into a flat <see cref="Option{T}"/>.
         /// Returns the inner option when <c>Some</c>, or <c>None</c> when the outer option is <c>None</c>.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var flat = Option.Some(Option.Some(42)).Flatten();           // Some(42)
+        /// var none = Option.Some(Option&lt;int&gt;.None()).Flatten();     // None
+        /// var outerNone = Option&lt;Option&lt;int&gt;&gt;.None().Flatten(); // None
+        /// </code>
+        /// </example>
         public static Option<T> Flatten<T>(this Option<Option<T>> option)
             => option.DefaultWith(Option<T>.None);
     }

--- a/src/Result/AsyncResultExtensions.cs
+++ b/src/Result/AsyncResultExtensions.cs
@@ -3,10 +3,11 @@ using System.Threading.Tasks;
 
 namespace Svan.Monads
 {
+    /// <summary>Async extension methods for <see cref="Result{TError,TSuccess}"/> enabling fluent async pipelines.</summary>
     public static class AsyncResultExtensions
     {
         /// <summary>
-        /// Flips a <c>Result&lt;TError, Task&lt;TSuccess&gt;&gt;</c> into a <c>Task&lt;Result&lt;TError, TSuccess&gt;&gt;</c>.
+        /// Flips a <see cref="Result{TError, TSuccess}"/> of <see cref="Task{TResult}"/> into a <see cref="Task{TResult}"/> of <see cref="Result{TError, TSuccess}"/>.
         /// Awaits the inner task when <c>Success</c>, returns the error immediately when <c>Error</c>.
         /// </summary>
         public static async Task<Result<TError, TSuccess>> Sequence<TError, TSuccess>(
@@ -22,9 +23,17 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Binds an async function over a <c>Task&lt;Result&lt;TError, TSuccess&gt;&gt;</c>.
+        /// Binds an async function over a <see cref="Task{TResult}"/> of <see cref="Result{TError, TSuccess}"/>.
         /// The binder is only called when the result is <c>Success</c>; otherwise short-circuits with the existing error.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// async Task&lt;Result&lt;string, string&gt;&gt; LookupUsername(int userId) { ... }
+        ///
+        /// var username = await ParseUserId("42")
+        ///     .BindAsync(id => LookupUsername(id));
+        /// </code>
+        /// </example>
         public static async Task<Result<TError, TOut>> BindAsync<TError, TSuccess, TOut>(
             this Task<Result<TError, TSuccess>> resultTask,
             Func<TSuccess, Task<Result<TError, TOut>>> binder)
@@ -34,9 +43,18 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Maps an async function over a <c>Task&lt;Result&lt;TError, TSuccess&gt;&gt;</c>.
+        /// Maps an async function over a <see cref="Task{TResult}"/> of <see cref="Result{TError, TSuccess}"/>.
         /// The mapper is only called when the result is <c>Success</c>; otherwise short-circuits with the existing error.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// async Task&lt;string&gt; FormatGreeting(string username) { ... }
+        ///
+        /// var greeting = await ParseUserId("42")
+        ///     .BindAsync(id => LookupUsername(id))
+        ///     .MapAsync(name => FormatGreeting(name));
+        /// </code>
+        /// </example>
         public static async Task<Result<TError, TOut>> MapAsync<TError, TSuccess, TOut>(
             this Task<Result<TError, TSuccess>> resultTask,
             Func<TSuccess, Task<TOut>> mapper)

--- a/src/Result/Result.cs
+++ b/src/Result/Result.cs
@@ -5,12 +5,26 @@ namespace Svan.Monads
     /// <summary>
     /// Union of <c>TError</c> and <c>TSuccess</c> with monad features for railway-oriented error handling.
     /// </summary>
+    /// <example>
+    /// <code>
+    /// Result&lt;string, int&gt; Divide(int a, int b) =>
+    ///     b == 0 ? Result&lt;string, int&gt;.Error("division by zero") : Result&lt;string, int&gt;.Success(a / b);
+    ///
+    /// var result = Divide(10, 2)
+    ///     .Bind(n => Divide(n, 1))
+    ///     .Map(n => n * 3)
+    ///     .DefaultWith(_ => 0);
+    /// // result == 15
+    /// </code>
+    /// </example>
     public class Result<TError, TSuccess> : Union<TError, TSuccess>
     {
         internal Result(Left<TError> value) : base(value) { }
         internal Result(Right<TSuccess> value) : base(value) { }
 
+        /// <summary>Creates an <c>Error</c> result with <paramref name="value"/>.</summary>
         public static Result<TError, TSuccess> Error(TError value) => new(new Left<TError>(value));
+        /// <summary>Creates a <c>Success</c> result with <paramref name="value"/>.</summary>
         public static Result<TError, TSuccess> Success(TSuccess value) => new(new Right<TSuccess>(value));
 
         /// <summary>
@@ -34,14 +48,24 @@ namespace Svan.Monads
         public TSuccess SuccessValue() => IsSuccess() ? AsRight : throw new NullReferenceException();
 
         /// <summary>
-        /// Bind the result to a new <c>Result&lt;TError, TOut&gt;</c> using a binder function.
+        /// Bind the result to a new <see cref="Result{TError, TSuccess}"/> using a binder function.
         /// The binder is only called when <c>Success</c>; otherwise short-circuits with the existing error.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// Result&lt;string, int&gt; Halve(int n) =>
+        ///     n % 2 == 0 ? Result&lt;string, int&gt;.Success(n / 2) : Result&lt;string, int&gt;.Error("odd");
+        ///
+        /// var result  = Result&lt;string, int&gt;.Success(10).Bind(Halve); // Success(5)
+        /// var error   = Result&lt;string, int&gt;.Success(3).Bind(Halve);  // Error("odd")
+        /// var skipped = Result&lt;string, int&gt;.Error("fail").Bind(Halve); // Error("fail") — binder not called
+        /// </code>
+        /// </example>
         public Result<TError, TOut> Bind<TOut>(Func<TSuccess, Result<TError, TOut>> binder)
             => Match(Result<TError, TOut>.Error, binder);
 
         /// <summary>
-        /// Bind the error to a new <c>Result&lt;TOut, TSuccess&gt;</c> using a binder function.
+        /// Bind the error to a new <see cref="Result{TError, TSuccess}"/> using a binder function.
         /// The binder is only called when <c>Error</c>; otherwise short-circuits with the existing success value.
         /// </summary>
         public Result<TOut, TSuccess> BindError<TOut>(Func<TError, Result<TOut, TSuccess>> binder)
@@ -50,6 +74,15 @@ namespace Svan.Monads
         /// <summary>
         /// Recover from <c>TError</c> by providing a <c>TSuccess</c> or a new error <c>TOut</c>.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var recovered = Result&lt;int, int&gt;.Error(0)
+        ///     .Recover(e => Result&lt;string, int&gt;.Success(e + 1)); // Success(1)
+        ///
+        /// var reErrored = Result&lt;int, int&gt;.Error(0)
+        ///     .Recover(e => Result&lt;string, int&gt;.Error("still bad")); // Error("still bad")
+        /// </code>
+        /// </example>
         public Result<TOut, TSuccess> Recover<TOut>(Func<TError, Result<TOut, TSuccess>> recover)
             => BindError(recover);
 
@@ -57,6 +90,12 @@ namespace Svan.Monads
         /// Map the success value to a new type using a mapping function.
         /// The mapper is only called when <c>Success</c>; otherwise short-circuits with the existing error.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var doubled = Result&lt;string, int&gt;.Success(21).Map(x => x * 2); // Success(42)
+        /// var err     = Result&lt;string, int&gt;.Error("fail").Map(x => x * 2); // Error("fail")
+        /// </code>
+        /// </example>
         public Result<TError, TOut> Map<TOut>(Func<TSuccess, TOut> mapSuccess)
             => Match(
                 Result<TError, TOut>.Error,
@@ -66,6 +105,12 @@ namespace Svan.Monads
         /// Map the error value to a new type using a mapping function.
         /// The mapper is only called when <c>Error</c>; otherwise short-circuits with the existing success value.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var upper   = Result&lt;string, int&gt;.Error("fail").MapError(e => e.ToUpper()); // Error("FAIL")
+        /// var success = Result&lt;string, int&gt;.Success(42).MapError(e => e.ToUpper());   // Success(42)
+        /// </code>
+        /// </example>
         public Result<TOut, TSuccess> MapError<TOut>(Func<TError, TOut> mapError)
             => Match(
                 error => Result<TOut, TSuccess>.Error(mapError(error)),
@@ -76,6 +121,12 @@ namespace Svan.Monads
         /// </summary>
         /// <param name="do">An action that takes a single parameter of <see cref="TSuccess"/></param>
         /// <returns>The current state of the Result</returns>
+        /// <example>
+        /// <code>
+        /// Result&lt;string, int&gt;.Success(42).Do(n => Console.WriteLine(n));    // prints 42
+        /// Result&lt;string, int&gt;.Error("fail").Do(n => Console.WriteLine(n)); // nothing printed
+        /// </code>
+        /// </example>
         public Result<TError, TSuccess> Do(Action<TSuccess> @do)
         {
             if (IsSuccess())
@@ -104,6 +155,12 @@ namespace Svan.Monads
         /// <summary>
         /// Get the value of <c>TSuccess</c> or a default value from the supplied function.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var value    = Result&lt;string, int&gt;.Success(42).DefaultWith(_ => 0); // 42
+        /// var fallback = Result&lt;string, int&gt;.Error("fail").DefaultWith(_ => 0); // 0
+        /// </code>
+        /// </example>
         public TSuccess DefaultWith(Func<TError, TSuccess> fallback)
             => Match(fallback, success => success);
 
@@ -116,6 +173,12 @@ namespace Svan.Monads
         /// <summary>
         /// Get the value of <c>TSuccess</c> or throw a <see cref="NullReferenceException"/>.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var value = Result&lt;string, int&gt;.Success(42).OrThrow(); // 42
+        /// Result&lt;string, int&gt;.Error("fail").OrThrow();           // throws InvalidOperationException
+        /// </code>
+        /// </example>
         public TSuccess OrThrow()
             => Match(
                 error => throw new InvalidOperationException($"Expected a successful value of {typeof(TSuccess).Name} but was {error}."),
@@ -124,6 +187,12 @@ namespace Svan.Monads
         /// <summary>
         /// Fold into value of type <c>TOut</c> with supplied functions for case <c>TError</c> and case <c>TSuccess</c>.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var msg = Result&lt;string, int&gt;.Success(42).Fold(e => $"error: {e}", n => $"got {n}"); // "got 42"
+        /// var err = Result&lt;string, int&gt;.Error("oops").Fold(e => $"error: {e}", n => $"got {n}"); // "error: oops"
+        /// </code>
+        /// </example>
         public TOut Fold<TOut>(Func<TError, TOut> caseError, Func<TSuccess, TOut> caseSuccess)
             => Match(caseError, caseSuccess);
 
@@ -226,9 +295,14 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Downcast to an <c>Option&lt;TSuccess&gt;</c>. When the result is <c>Error</c> it will return <c>None</c>.
+        /// Downcast to an <see cref="Option{T}"/>. When the result is <c>Error</c> it will return <c>None</c>.
         /// </summary>
-        /// <returns></returns>
+        /// <example>
+        /// <code>
+        /// var some = Result&lt;string, int&gt;.Success(42).ToOption(); // Some(42)
+        /// var none = Result&lt;string, int&gt;.Error("fail").ToOption(); // None
+        /// </code>
+        /// </example>
         public Option<TSuccess> ToOption()
             => Match(
                 _ => Option<TSuccess>.None(),

--- a/src/Result/Result.cs
+++ b/src/Result/Result.cs
@@ -3,7 +3,7 @@ using System;
 namespace Svan.Monads
 {
     /// <summary>
-    /// Union of <c>TError</c> and <c>TSuccess</c> with monad features for railway-oriented error handling.
+    /// Union of <typeparamref name="TError"/> and <typeparamref name="TSuccess"/> with monad features for railway-oriented error handling.
     /// </summary>
     /// <example>
     /// <code>
@@ -22,9 +22,9 @@ namespace Svan.Monads
         internal Result(Left<TError> value) : base(value) { }
         internal Result(Right<TSuccess> value) : base(value) { }
 
-        /// <summary>Creates an <c>Error</c> result with <paramref name="value"/>.</summary>
+        /// <summary>Creates a <typeparamref name="TError"/> result with <paramref name="value"/>.</summary>
         public static Result<TError, TSuccess> Error(TError value) => new(new Left<TError>(value));
-        /// <summary>Creates a <c>Success</c> result with <paramref name="value"/>.</summary>
+        /// <summary>Creates a <typeparamref name="TSuccess"/> result with <paramref name="value"/>.</summary>
         public static Result<TError, TSuccess> Success(TSuccess value) => new(new Right<TSuccess>(value));
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Svan.Monads
             => Match(binder, Result<TOut, TSuccess>.Success);
 
         /// <summary>
-        /// Recover from <c>TError</c> by providing a <c>TSuccess</c> or a new error <c>TOut</c>.
+        /// Recover from <typeparamref name="TError"/> by providing a <typeparamref name="TSuccess"/> or a new error <typeparamref name="TOut"/>.
         /// </summary>
         /// <example>
         /// <code>
@@ -117,9 +117,9 @@ namespace Svan.Monads
                 Result<TOut, TSuccess>.Success);
 
         /// <summary>
-        /// Do lets you fire and forget an action that is executed only when the value is <see cref="TSuccess"/>
+        /// Do lets you fire and forget an action that is executed only when the value is <typeparamref name="TSuccess"/>
         /// </summary>
-        /// <param name="do">An action that takes a single parameter of <see cref="TSuccess"/></param>
+        /// <param name="do">An action that takes a single parameter of <typeparamref name="TSuccess"/></param>
         /// <returns>The current state of the Result</returns>
         /// <example>
         /// <code>
@@ -138,9 +138,9 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Do lets you fire and forget an action that is executed only when the value is <see cref="TError"/>
+        /// Do lets you fire and forget an action that is executed only when the value is <typeparamref name="TError"/>
         /// </summary>
-        /// <param name="do">An action that takes a single parameter of <see cref="TError"/></param>
+        /// <param name="do">An action that takes a single parameter of <typeparamref name="TError"/></param>
         /// <returns>The current state of the Result</returns>
         public Result<TError, TSuccess> DoIfError(Action<TError> @do)
         {
@@ -153,7 +153,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Get the value of <c>TSuccess</c> or a default value from the supplied function.
+        /// Get the value of <typeparamref name="TSuccess"/> or a default value from the supplied function.
         /// </summary>
         /// <example>
         /// <code>
@@ -165,13 +165,13 @@ namespace Svan.Monads
             => Match(fallback, success => success);
 
         /// <summary>
-        /// Get the value of <c>TSuccess</c> or a default value from the supplied value.
+        /// Get the value of <typeparamref name="TSuccess"/> or a default value from the supplied value.
         /// </summary>
         public TSuccess DefaultWith(TSuccess fallback)
             => Match(_ => fallback, success => success);
 
         /// <summary>
-        /// Get the value of <c>TSuccess</c> or throw a <see cref="NullReferenceException"/>.
+        /// Get the value of <typeparamref name="TSuccess"/> or throw a <see cref="NullReferenceException"/>.
         /// </summary>
         /// <example>
         /// <code>
@@ -185,7 +185,7 @@ namespace Svan.Monads
                 success => success);
 
         /// <summary>
-        /// Fold into value of type <c>TOut</c> with supplied functions for case <c>TError</c> and case <c>TSuccess</c>.
+        /// Fold into value of type <typeparamref name="TOut"/> with supplied functions for case <typeparamref name="TError"/> and case <typeparamref name="TSuccess"/>.
         /// </summary>
         /// <example>
         /// <code>
@@ -197,7 +197,7 @@ namespace Svan.Monads
             => Match(caseError, caseSuccess);
 
         /// <summary>
-        /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
+        /// Combine several results into a new result of <typeparamref name="TSuccessOut"/> or <typeparamref name="TError"/> if any of the provided results has an error
         /// </summary>
         public Result<TError, TSuccessOut> Zip<TSuccessOut, TSuccessOther>(
             Result<TError, TSuccessOther> other,
@@ -212,7 +212,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
+        /// Combine several results into a new result of <typeparamref name="TSuccessOut"/> or <typeparamref name="TError"/> if any of the provided results has an error
         /// </summary>
         public Result<TError, TSuccessOut> Zip<TSuccessOut, TSuccessFirstOther, TSuccessSecondOther>(
             Result<TError, TSuccessFirstOther> firstOther,
@@ -230,7 +230,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
+        /// Combine several results into a new result of <typeparamref name="TSuccessOut"/> or <typeparamref name="TError"/> if any of the provided results has an error
         /// </summary>
         public Result<TError, TSuccessOut> Zip<TSuccessOut, TSuccessFirstOther, TSuccessSecondOther, TSuccessThirdOther>(
             Result<TError, TSuccessFirstOther> firstOther,
@@ -255,7 +255,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
+        /// Combine several results into a new result of <typeparamref name="TSuccessOut"/> or <typeparamref name="TError"/> if any of the provided results has an error
         /// </summary>
         public Result<TError, TSuccessOut> Zip<
             TSuccessOut,

--- a/src/Result/ResultConstructors.cs
+++ b/src/Result/ResultConstructors.cs
@@ -4,17 +4,17 @@ namespace Svan.Monads;
 public static class Result
 {
     /// <summary>
-    /// Creates a <c>Success</c> result with the provided value.
+    /// Creates a <typeparamref name="TSuccess"/> result with the provided value.
     /// </summary>
     public static Result<TError, TSuccess> Success<TError, TSuccess>(TSuccess value) => Result<TError, TSuccess>.Success(value);
 
     /// <summary>
-    /// Creates an <c>Error</c> result with the provided value.
+    /// Creates a <typeparamref name="TError"/> result with the provided value.
     /// </summary>
     public static Result<TError, TSuccess> Error<TError, TSuccess>(TError value) => Result<TError, TSuccess>.Error(value);
 
     /// <summary>
-    /// Creates a <c>Success</c> result with the provided value.
+    /// Creates a <typeparamref name="TSuccess"/> result with the provided value.
     /// </summary>
     /// <example>
     /// <code>
@@ -24,7 +24,7 @@ public static class Result
     public static Result<TError, TSuccess> ToSuccess<TError, TSuccess>(this TSuccess value) => Success<TError, TSuccess>(value);
 
     /// <summary>
-    /// Creates an <c>Error</c> result with the provided value.
+    /// Creates a <typeparamref name="TError"/> result with the provided value.
     /// </summary>
     /// <example>
     /// <code>

--- a/src/Result/ResultConstructors.cs
+++ b/src/Result/ResultConstructors.cs
@@ -1,5 +1,6 @@
 namespace Svan.Monads;
 
+/// <summary>Non-generic factory methods for creating <see cref="Result{TError,TSuccess}"/> instances.</summary>
 public static class Result
 {
     /// <summary>
@@ -15,10 +16,20 @@ public static class Result
     /// <summary>
     /// Creates a <c>Success</c> result with the provided value.
     /// </summary>
+    /// <example>
+    /// <code>
+    /// var result = 42.ToSuccess&lt;string, int&gt;(); // Success(42)
+    /// </code>
+    /// </example>
     public static Result<TError, TSuccess> ToSuccess<TError, TSuccess>(this TSuccess value) => Success<TError, TSuccess>(value);
 
     /// <summary>
     /// Creates an <c>Error</c> result with the provided value.
     /// </summary>
+    /// <example>
+    /// <code>
+    /// var result = "something went wrong".ToError&lt;string, int&gt;(); // Error("something went wrong")
+    /// </code>
+    /// </example>
     public static Result<TError, TSuccess> ToError<TError, TSuccess>(this TError value) => Error<TError, TSuccess>(value);
 }

--- a/src/Result/ResultExtensions.cs
+++ b/src/Result/ResultExtensions.cs
@@ -3,12 +3,24 @@ using System.Collections.Generic;
 
 namespace Svan.Monads
 {
+    /// <summary>Extension methods for combining and transforming <see cref="Result{TError,TSuccess}"/> values.</summary>
     public static class ResultExtensions
     {
         /// <summary>
         /// Merge two or more results together. Merge will only be performed if all involved results resolve to <c>TSuccess</c>.
         /// </summary>
         /// <returns>The success values merged into a result using a tuple</returns>
+        /// <example>
+        /// <code>
+        /// var merged = Result&lt;string, int&gt;.Success(1).Merge(Result&lt;string, string&gt;.Success("a"));
+        /// // Success(Tuple(1, "a"))
+        ///
+        /// // Chain further Merge calls to collect up to five values:
+        /// var triple = Result&lt;string, int&gt;.Success(1)
+        ///     .Merge(Result&lt;string, int&gt;.Success(2))
+        ///     .Merge(Result&lt;string, int&gt;.Success(3));
+        /// </code>
+        /// </example>
         public static Result<TError, Tuple<TFirst, TSecond>> Merge<TError, TFirst, TSecond>(
             this Result<TError, TFirst> first, Result<TError, TSecond> second) =>
                 first.Zip(second, (f, s) => new Tuple<TFirst, TSecond>(f, s));
@@ -41,6 +53,15 @@ namespace Svan.Monads
         /// Combine a sequence of results together. Returns <c>Success</c> with all values if every result is <c>Success</c>,
         /// or the first <c>Error</c> encountered.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var all  = new[] { Result&lt;string, int&gt;.Success(1), Result&lt;string, int&gt;.Success(2) }.Sequence();
+        /// // Success([1, 2])
+        ///
+        /// var fail = new[] { Result&lt;string, int&gt;.Success(1), Result&lt;string, int&gt;.Error("oops") }.Sequence();
+        /// // Error("oops")
+        /// </code>
+        /// </example>
         public static Result<TError, IEnumerable<TSuccess>> Sequence<TError, TSuccess>(this IEnumerable<Result<TError, TSuccess>> results)
         {
             var values = new List<TSuccess>();
@@ -59,9 +80,21 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Flattens a nested <c>Result&lt;TError, Result&lt;TError, TSuccess&gt;&gt;</c> into a <c>Result&lt;TError, TSuccess&gt;</c>.
+        /// Flattens a nested <see cref="Result{TError, TSuccess}"/> where the success is itself a <see cref="Result{TError, TSuccess}"/> into a flat <see cref="Result{TError, TSuccess}"/>.
         /// Returns the inner result when <c>Success</c>, or propagates the outer error when <c>Error</c>.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var flat      = Result&lt;string, Result&lt;string, int&gt;&gt;.Success(Result&lt;string, int&gt;.Success(42)).Flatten();
+        /// // Success(42)
+        ///
+        /// var innerErr  = Result&lt;string, Result&lt;string, int&gt;&gt;.Success(Result&lt;string, int&gt;.Error("inner")).Flatten();
+        /// // Error("inner")
+        ///
+        /// var outerErr  = Result&lt;string, Result&lt;string, int&gt;&gt;.Error("outer").Flatten();
+        /// // Error("outer")
+        /// </code>
+        /// </example>
         public static Result<TError, TSuccess> Flatten<TError, TSuccess>(this Result<TError, Result<TError, TSuccess>> result)
             => result.DefaultWith(Result<TError, TSuccess>.Error);
     }

--- a/src/Result/ResultExtensions.cs
+++ b/src/Result/ResultExtensions.cs
@@ -7,7 +7,7 @@ namespace Svan.Monads
     public static class ResultExtensions
     {
         /// <summary>
-        /// Merge two or more results together. Merge will only be performed if all involved results resolve to <c>TSuccess</c>.
+        /// Merge two or more results together. Merge will only be performed if all involved results are successful.
         /// </summary>
         /// <returns>The success values merged into a result using a tuple</returns>
         /// <example>
@@ -26,7 +26,7 @@ namespace Svan.Monads
                 first.Zip(second, (f, s) => new Tuple<TFirst, TSecond>(f, s));
 
         /// <summary>
-        /// Merge two or more results together. Merge will only be performed if all involved results resolve to <c>TSuccess</c>.
+        /// Merge two or more results together. Merge will only be performed if all involved results are successful.
         /// </summary>
         /// <returns>The success values merged into a result using a tuple</returns>
         public static Result<TError, Tuple<TFirst, TSecond, TThird>> Merge<TError, TFirst, TSecond, TThird>(
@@ -34,7 +34,7 @@ namespace Svan.Monads
                 group.Zip(other, (g, o) => new Tuple<TFirst, TSecond, TThird>(g.Item1, g.Item2, o));
 
         /// <summary>
-        /// Merge two or more results together. Merge will only be performed if all involved results resolve to <c>TSuccess</c>.
+        /// Merge two or more results together. Merge will only be performed if all involved results are successful.
         /// </summary>
         /// <returns>The success values merged into a result using a tuple</returns>
         public static Result<TError, Tuple<TFirst, TSecond, TThird, TFourth>> Merge<TError, TFirst, TSecond, TThird, TFourth>(
@@ -42,7 +42,7 @@ namespace Svan.Monads
                 group.Zip(other, (g, o) => new Tuple<TFirst, TSecond, TThird, TFourth>(g.Item1, g.Item2, g.Item3, o));
 
         /// <summary>
-        /// Merge two or more results together. Merge will only be performed if all involved results resolve to <c>TSuccess</c>.
+        /// Merge two or more results together. Merge will only be performed if all involved results are successful.
         /// </summary>
         /// <returns>The success values merged into a result using a tuple</returns>
         public static Result<TError, Tuple<TFirst, TSecond, TThird, TFourth, TFifth>> Merge<TError, TFirst, TSecond, TThird, TFourth, TFifth>(

--- a/src/Svan.Monads.csproj
+++ b/src/Svan.Monads.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <PublishWithAspNetCoreTargetManifest>false</PublishWithAspNetCoreTargetManifest>
     <PackageId>Svan.Monads</PackageId>

--- a/src/Try/AsyncTryExtensions.cs
+++ b/src/Try/AsyncTryExtensions.cs
@@ -3,10 +3,11 @@ using System.Threading.Tasks;
 
 namespace Svan.Monads
 {
+    /// <summary>Async extension methods for <see cref="Try{TSuccess}"/> enabling fluent async pipelines.</summary>
     public static class AsyncTryExtensions
     {
         /// <summary>
-        /// Flips a <c>Try&lt;Task&lt;TSuccess&gt;&gt;</c> into a <c>Task&lt;Try&lt;TSuccess&gt;&gt;</c>.
+        /// Flips a <see cref="Try{TSuccess}"/> of <see cref="Task{TResult}"/> into a <see cref="Task{TResult}"/> of <see cref="Try{TSuccess}"/>.
         /// Awaits the inner task when <c>Success</c>, returns the error immediately when <c>Error</c>.
         /// If the inner task faults, the exception is caught and returned as the error state.
         /// </summary>
@@ -26,7 +27,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Binds an async function over a <c>Task&lt;Try&lt;TSuccess&gt;&gt;</c>.
+        /// Binds an async function over a <see cref="Task{TResult}"/> of <see cref="Try{TSuccess}"/>.
         /// The binder is only called when the result is <c>Success</c>; otherwise short-circuits with the existing error.
         /// Exceptions thrown by the binder or faulted tasks will propagate as faulted tasks.
         /// Use <see cref="BindCatchingAsync{TSuccess, TOut}"/> to catch exceptions into the error state instead.
@@ -42,7 +43,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Maps an async function over a <c>Task&lt;Try&lt;TSuccess&gt;&gt;</c>.
+        /// Maps an async function over a <see cref="Task{TResult}"/> of <see cref="Try{TSuccess}"/>.
         /// The mapper is only called when the result is <c>Success</c>; otherwise short-circuits with the existing error.
         /// Exceptions thrown by the mapper or faulted tasks will propagate as faulted tasks.
         /// Use <see cref="MapCatchingAsync{TSuccess, TOut}"/> to catch exceptions into the error state instead.
@@ -56,7 +57,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Binds an async function over a <c>Task&lt;Try&lt;TSuccess&gt;&gt;</c>, catching any exceptions.
+        /// Binds an async function over a <see cref="Task{TResult}"/> of <see cref="Try{TSuccess}"/>, catching any exceptions.
         /// Exceptions thrown by the binder or faulted tasks are caught and returned as the error state,
         /// keeping the chain inside the monad.
         /// </summary>
@@ -77,7 +78,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Maps an async function over a <c>Task&lt;Try&lt;TSuccess&gt;&gt;</c>, catching any exceptions.
+        /// Maps an async function over a <see cref="Task{TResult}"/> of <see cref="Try{TSuccess}"/>, catching any exceptions.
         /// Exceptions thrown by the mapper or faulted tasks are caught and returned as the error state,
         /// keeping the chain inside the monad.
         /// </summary>

--- a/src/Try/Try.cs
+++ b/src/Try/Try.cs
@@ -3,24 +3,46 @@ using System;
 namespace Svan.Monads
 {
     /// <summary>
-    /// A specialization of <c>Result&lt;Exception, TSuccess&gt;</c> that provides exception-catching operations.
+    /// A specialization of <see cref="Result{TError, TSuccess}"/> that provides exception-catching operations.
     /// </summary>
+    /// <example>
+    /// <code>
+    /// var result = Try.Catching(() => int.Parse("42"))
+    ///     .MapCatching(n => n * 2)
+    ///     .DefaultWith(_ => 0);
+    /// // result == 84
+    ///
+    /// var failed = Try.Catching(() => int.Parse("abc"))
+    ///     .MapCatching(n => n * 2)
+    ///     .DefaultWith(_ => 0);
+    /// // failed == 0 (FormatException caught at each step)
+    /// </code>
+    /// </example>
     public class Try<TSuccess> : Result<Exception, TSuccess>
     {
         internal Try(Left<Exception> value) : base(value) { }
         internal Try(Right<TSuccess> value) : base(value) { }
 
+        /// <summary>Creates a <c>Try</c> in the error state wrapping <paramref name="value"/>.</summary>
         public static Try<TSuccess> Exception(Exception value) => new(new Left<Exception>(value));
+        /// <summary>Creates a <c>Try</c> in the success state wrapping <paramref name="value"/>.</summary>
         public new static Try<TSuccess> Success(TSuccess value) => new(new Right<TSuccess>(value));
 
         /// <summary>
-        /// Upcast to <c>Result&lt;Exception, TSuccess&gt;</c>.
+        /// Upcast to <see cref="Result{TError, TSuccess}"/>.
         /// </summary>
         public Result<Exception, TSuccess> ToResult() => this;
 
         /// <summary>
         /// Map the success value using a mapping function, catching any exception thrown by the mapper.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var result = Try.Catching(() => "42").MapCatching(int.Parse); // Success(42)
+        /// var failed = Try.Catching(() => "abc").MapCatching(int.Parse); // Exception(FormatException)
+        /// // Unlike Map, exceptions thrown by the mapper are caught rather than propagated.
+        /// </code>
+        /// </example>
         public Try<TOut> MapCatching<TOut>(Func<TSuccess, TOut> mapper)
             => Fold<Try<TOut>>(
                  Try.Exception<TOut>,
@@ -30,6 +52,18 @@ namespace Svan.Monads
         /// Bind using a binder function, catching any exception thrown by the binder.
         /// The binder is only called when <c>Success</c>; otherwise short-circuits with the existing error.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// Try&lt;int&gt; ParsePositive(string s)
+        /// {
+        ///     var n = int.Parse(s); // throws if invalid
+        ///     return n > 0 ? Try.Success(n) : throw new ArgumentException("must be positive");
+        /// }
+        ///
+        /// var result = Try.Catching(() => "42").BindCatching(ParsePositive); // Success(42)
+        /// var failed = Try.Catching(() => "abc").BindCatching(ParsePositive); // Exception(FormatException)
+        /// </code>
+        /// </example>
         public Try<TOut> BindCatching<TOut>(Func<TSuccess, Try<TOut>> binder)
         {
             if (!IsSuccess()) return Try.Exception<TOut>(ErrorValue());

--- a/src/Try/Try.cs
+++ b/src/Try/Try.cs
@@ -98,9 +98,9 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Do lets you fire and forget an action that is executed only when the value is <see cref="TSuccess"/>
+        /// Do lets you fire and forget an action that is executed only when the value is <typeparamref name="TSuccess"/>
         /// </summary>
-        /// <param name="do">An action that takes a single parameter of <see cref="TSuccess"/></param>
+        /// <param name="do">An action that takes a single parameter of <typeparamref name="TSuccess"/></param>
         /// <returns>The current state of the Result</returns>
         public new Try<TSuccess> Do(Action<TSuccess> @do)
         {
@@ -122,7 +122,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
+        /// Combine several results into a new result of <typeparamref name="TSuccessOut"/> or <see cref="Exception"/> if any of the provided results has an error
         /// </summary>
         public Try<TSuccessOut> Zip<TSuccessOut, TSuccessOther>(
             Try<TSuccessOther> other,
@@ -133,7 +133,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
+        /// Combine several results into a new result of <typeparamref name="TSuccessOut"/> or <see cref="Exception"/> if any of the provided results has an error
         /// </summary>
         public Try<TSuccessOut> Zip<TSuccessOut, TSuccessFirstOther, TSuccessSecondOther>(
             Try<TSuccessFirstOther> firstOther,
@@ -145,7 +145,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
+        /// Combine several results into a new result of <typeparamref name="TSuccessOut"/> or <see cref="Exception"/> if any of the provided results has an error
         /// </summary>
         public Try<TSuccessOut> Zip<TSuccessOut, TSuccessFirstOther, TSuccessSecondOther, TSuccessThirdOther>(
             Try<TSuccessFirstOther> firstOther,
@@ -158,7 +158,7 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Combine several results into a new result of <c>TSuccessOut</c> or <c>TError</c> if any of the provided results has an error
+        /// Combine several results into a new result of <typeparamref name="TSuccessOut"/> or <see cref="Exception"/> if any of the provided results has an error
         /// </summary>
         public Try<TSuccessOut> Zip<
             TSuccessOut,

--- a/src/Try/TryConstructors.cs
+++ b/src/Try/TryConstructors.cs
@@ -3,7 +3,7 @@ using System;
 namespace Svan.Monads;
 
 /// <summary>
-/// Factory for creating <c>Try&lt;TSuccess&gt;</c> instances by catching exceptions.
+/// Factory for creating <see cref="Try{TSuccess}"/> instances by catching exceptions.
 /// </summary>
 public static class Try
 {
@@ -11,6 +11,12 @@ public static class Try
     /// Execute <paramref name="codeBlock"/> and return its result as <c>Success</c>.
     /// If the code block throws, the exception is caught and returned as the error state.
     /// </summary>
+    /// <example>
+    /// <code>
+    /// var success = Try.Catching(() => int.Parse("42")); // Success(42)
+    /// var failed  = Try.Catching(() => int.Parse("abc")); // Exception(FormatException)
+    /// </code>
+    /// </example>
     public static Try<TSuccess> Catching<TSuccess>(Func<TSuccess> codeBlock)
     {
         try

--- a/src/Try/TryConstructors.cs
+++ b/src/Try/TryConstructors.cs
@@ -30,7 +30,7 @@ public static class Try
     }
 
     /// <summary>
-    /// Creates a <c>Success</c> try with the provided value.
+    /// Creates a <typeparamref name="TSuccess"/> try with the provided value.
     /// </summary>
     public static Try<TSuccess> Success<TSuccess>(TSuccess value) => Try<TSuccess>.Success(value);
 
@@ -40,7 +40,7 @@ public static class Try
     public static Try<TSuccess> Exception<TSuccess>(Exception value) => Try<TSuccess>.Exception(value);
 
     /// <summary>
-    /// Creates a <c>Success</c> try with the provided value.
+    /// Creates a <typeparamref name="TSuccess"/> try with the provided value.
     /// </summary>
     public static Try<TSuccess> ToSuccess<TSuccess>(this TSuccess value) => Success(value);
 

--- a/src/Try/TryExtensions.cs
+++ b/src/Try/TryExtensions.cs
@@ -3,12 +3,20 @@ using System.Collections.Generic;
 
 namespace Svan.Monads
 {
+    /// <summary>Extension methods for combining and transforming <see cref="Try{TSuccess}"/> values.</summary>
     public static class TryExtensions
     {
         /// <summary>
         /// Combine a sequence of tries together. Returns <c>Success</c> with all values if every try is <c>Success</c>,
         /// or the first <c>Exception</c> encountered.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var all  = new[] { Try.Success(1), Try.Success(2) }.Sequence(); // Success([1, 2])
+        /// var fail = new[] { Try.Success(1), Try.Exception&lt;int&gt;(new Exception("oops")) }.Sequence();
+        /// // Exception("oops")
+        /// </code>
+        /// </example>
         public static Try<IEnumerable<TSuccess>> Sequence<TSuccess>(this IEnumerable<Try<TSuccess>> tries)
         {
             var values = new List<TSuccess>();
@@ -27,9 +35,16 @@ namespace Svan.Monads
         }
 
         /// <summary>
-        /// Flattens a nested <c>Try&lt;Try&lt;TSuccess&gt;&gt;</c> into a <c>Try&lt;TSuccess&gt;</c>.
+        /// Flattens a nested <see cref="Try{TSuccess}"/> where the success is itself a <see cref="Try{TSuccess}"/> into a flat <see cref="Try{TSuccess}"/>.
         /// Returns the inner try when <c>Success</c>, or propagates the outer exception when <c>Error</c>.
         /// </summary>
+        /// <example>
+        /// <code>
+        /// var flat     = Try.Success(Try.Success(42)).Flatten();  // Success(42)
+        /// var innerErr = Try.Success(Try.Exception&lt;int&gt;(new Exception("inner"))).Flatten();
+        /// // Exception("inner")
+        /// </code>
+        /// </example>
         public static Try<TSuccess> Flatten<TSuccess>(this Try<Try<TSuccess>> result)
             => result.DefaultWith(Try.Exception<TSuccess>);
     }

--- a/src/Union.cs
+++ b/src/Union.cs
@@ -2,13 +2,17 @@ using System;
 
 namespace Svan.Monads
 {
+    /// <summary>Wrapper that marks a value as the left case of a <see cref="Union{TLeft,TRight}"/>.</summary>
     public readonly struct Left<T>(T value)
     {
+        /// <summary>The wrapped left value.</summary>
         public T Value { get; } = value;
     }
 
+    /// <summary>Wrapper that marks a value as the right case of a <see cref="Union{TLeft,TRight}"/>.</summary>
     public readonly struct Right<T>(T value)
     {
+        /// <summary>The wrapped right value.</summary>
         public T Value { get; } = value;
     }
 

--- a/src/Union.cs
+++ b/src/Union.cs
@@ -25,6 +25,7 @@ namespace Svan.Monads
         private readonly TLeft _left;
         private readonly TRight _right;
 
+        /// <summary>Initializes the union with a <typeparamref name="TLeft"/> value.</summary>
         protected Union(Left<TLeft> value)
         {
             _isLeft = true;
@@ -32,6 +33,7 @@ namespace Svan.Monads
             _right = default!;
         }
 
+        /// <summary>Initializes the union with a <typeparamref name="TRight"/> value.</summary>
         protected Union(Right<TRight> value)
         {
             _isLeft = false;
@@ -39,22 +41,29 @@ namespace Svan.Monads
             _right = value.Value;
         }
 
+        /// <summary><see langword="true"/> when the union holds a <typeparamref name="TLeft"/> value.</summary>
         public bool IsLeft => _isLeft;
 
+        /// <summary><see langword="true"/> when the union holds a <typeparamref name="TRight"/> value.</summary>
         public bool IsRight => !_isLeft;
 
+        /// <summary>Returns the <typeparamref name="TLeft"/> value. Throws if the union holds a <typeparamref name="TRight"/> value.</summary>
         protected TLeft AsLeft => _isLeft
             ? _left
             : throw new NullReferenceException("Cannot access Left when value is Right.");
 
+        /// <summary>Returns the <typeparamref name="TRight"/> value. Throws if the union holds a <typeparamref name="TLeft"/> value.</summary>
         protected TRight AsRight => !_isLeft
             ? _right
             : throw new NullReferenceException("Cannot access Right when value is Left.");
 
+        /// <summary>Projects the union to <typeparamref name="TOut"/> by applying <paramref name="f0"/> for the left case or <paramref name="f1"/> for the right case.</summary>
         public TOut Match<TOut>(Func<TLeft, TOut> f0, Func<TRight, TOut> f1)
             => _isLeft ? f0(_left) : f1(_right);
 
+        /// <summary>Implicitly wraps a <see cref="Left{TLeft}"/> as a <see cref="Union{TLeft,TRight}"/>.</summary>
         public static implicit operator Union<TLeft, TRight>(Left<TLeft> value) => new(value);
+        /// <summary>Implicitly wraps a <see cref="Right{TRight}"/> as a <see cref="Union{TLeft,TRight}"/>.</summary>
         public static implicit operator Union<TLeft, TRight>(Right<TRight> value) => new(value);
     }
 }

--- a/tests/Svan.Monads.UnitTests.csproj
+++ b/tests/Svan.Monads.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/TestHelpers.cs
+++ b/tests/TestHelpers.cs
@@ -5,47 +5,53 @@ namespace Svan.Monads.UnitTests;
 
 public static class TestHelpers
 {
-    public static T AssertSome<T>(this Option<T> option)
+    extension<T>(Option<T> option)
     {
-        Assert.True(option.IsSome(), "Expected option to be SOME.");
-        return option.Value();
+        public T AssertSome()
+        {
+            Assert.True(option.IsSome(), "Expected option to be SOME.");
+            return option.Value();
+        }
+
+        public T AssertSome(T expected)
+        {
+            var value = option.AssertSome();
+            Assert.Equal(expected, value);
+            return value;
+        }
+
+        public void AssertNone()
+        {
+            Assert.True(option.IsNone(), $"Expected option to be NONE, but was SOME");
+        }
     }
 
-    public static T AssertSome<T>(this Option<T> option, T expected)
+    extension<TError, TSuccess>(Result<TError, TSuccess> result)
     {
-        var value = option.AssertSome();
-        Assert.Equal(expected, value);
-        return value;
-    }
+        public TSuccess AssertSuccess()
+        {
+            Assert.True(result.IsSuccess(), "Expected result to be SUCCESS.");
+            return result.SuccessValue();
+        }
 
-    public static void AssertNone<T>(this Option<T> option)
-    {
-        Assert.True(option.IsNone(), $"Expected option to be NONE, but was SOME");
-    }
+        public TSuccess AssertSuccess(TSuccess expected)
+        {
+            var value = result.AssertSuccess();
+            Assert.Equal(expected, value);
+            return value;
+        }
 
-    public static TSuccess AssertSuccess<TError, TSuccess>(this Result<TError, TSuccess> result)
-    {
-        Assert.True(result.IsSuccess(), "Expected result to be SUCCESS.");
-        return result.SuccessValue();
-    }
+        public TError AssertError()
+        {
+            Assert.True(result.IsError(), "Expected result to be ERROR");
+            return result.ErrorValue();
+        }
 
-    public static TSuccess AssertSuccess<TError, TSuccess>(this Result<TError, TSuccess> result, TSuccess expected)
-    {
-        var value = result.AssertSuccess();
-        Assert.Equal(expected, value);
-        return value;
-    }
-
-    public static TError AssertError<TError, TSuccess>(this Result<TError, TSuccess> result)
-    {
-        Assert.True(result.IsError(), "Expected result to be ERROR");
-        return result.ErrorValue();
-    }
-
-    public static TError AssertError<TError, TSuccess>(this Result<TError, TSuccess> result, TError expected)
-    {
-        var value = result.AssertError();
-        Assert.Equal(expected, value);
-        return value;
+        public TError AssertError(TError expected)
+        {
+            var value = result.AssertError();
+            Assert.Equal(expected, value);
+            return value;
+        }
     }
 }


### PR DESCRIPTION
                                                                                                                                                                                                                    
  - Upgrades all projects (library, tests, examples, CI, mise.toml) from `net9.0` / `dotnet 9` to `net10.0` / `dotnet 10`
  - Enables `<GenerateDocumentationFile>` in the library project so XML docs are included in the NuGet package                                                                                                                    
  - Adds comprehensive `<example>` / `<code>` blocks to every public API across `Option`, `Result`, `Either`, and `Try` — covering constructors, `Map`, `Bind`, `Filter`, `Do`, `Fold`, `DefaultWith`, `OrThrow`, `Flatten`,
  `Sequence`, `Merge`, and all async variants                                                                                                                                                                                     
  - Improves `<see cref="..."/>` usage over plain `<c>` tags throughout the XML comments
  - Refactors `TestHelpers.cs` to use the C# 14 `extension` member syntax